### PR TITLE
Publish to nuget.org with Trusted Publishing, not a stored key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,14 @@
 # deprecated or unlisted, never truly withdrawn, so a person decides. That was M8-20's rule and it
 # still holds — what changed is where the person stands. They used to run `dotnet nuget push` from
 # their own machine with their own key; they now approve a protected environment, and the workflow
-# pushes. Same gate, but the key is not on a laptop, the step is repeatable, and the push is
-# recorded against the run. See the `publish-nuget` job for the one-time setup.
+# pushes. Same gate, but the step is repeatable and the push is recorded against the run.
+#
+# AND THERE IS NO PUBLISHING SECRET ANYWHERE IN THIS REPOSITORY. Publishing uses nuget.org's
+# TRUSTED PUBLISHING: the job proves its identity with a GitHub OIDC token, nuget.org validates it
+# against a policy naming this owner, this repository, this workflow file and this environment, and
+# returns an API key valid for ONE HOUR. Nothing long-lived is stored, so nothing long-lived can
+# leak. nuget.org's own guidance now calls API keys "strongly discouraged" for automation.
+# See the `publish-nuget` job for the one-time setup.
 #
 # THE VERSION IS THE TAG. MinVer derives it (Directory.Build.props), which is why this workflow no
 # longer compares the two and why `fetch-depth: 0` below is load-bearing rather than tidy.
@@ -140,24 +146,12 @@ jobs:
             reviewer**. Nothing reaches nuget.org until somebody approves it, because a pushed
             version can be unlisted but never withdrawn.
 
-            Approve it and it pushes both packages. **If the `nuget-org` environment has no
-            `NUGET_API_KEY` yet**, the job stops and says so, having pushed nothing — download the
-            packages below and run these, in this order:
+            Approve it and it pushes both packages, `InfoCarrier.Core` first — the second
+            declares a dependency on it at the same version, and nuget.org rejects a package whose
+            dependency does not resolve.
 
-            ```bash
-            # InfoCarrier.Core FIRST: InfoCarrier.Core.AspNetCore depends on it at the same
-            # version, and nuget.org rejects a package whose dependency does not resolve.
-            #
-            # Exact filenames, not globs: `InfoCarrier.Core.*.nupkg` also matches
-            # InfoCarrier.Core.AspNetCore.
-            V=${{ github.ref_name }}; V=${V#v}
-            SRC=https://api.nuget.org/v3/index.json
-
-            dotnet nuget push "InfoCarrier.Core.$V.nupkg"             --source $SRC --api-key "$KEY"
-            dotnet nuget push "InfoCarrier.Core.AspNetCore.$V.nupkg"  --source $SRC --api-key "$KEY"
-            dotnet nuget push "InfoCarrier.Core.$V.snupkg"            --source $SRC --api-key "$KEY"
-            dotnet nuget push "InfoCarrier.Core.AspNetCore.$V.snupkg" --source $SRC --api-key "$KEY"
-            ```
+            Publishing uses **Trusted Publishing**: the job exchanges a GitHub OIDC token for an
+            API key valid for one hour. No publishing secret is stored in this repository.
 
             Known limitations for this release: [`docs/limitations.md`](docs/limitations.md).
 
@@ -171,19 +165,32 @@ jobs:
   # required reviewer approves it, the key is an environment secret rather than a personal one,
   # and every push is recorded against the run that made it. Dated note in docs/roadmap.md.
   #
-  # SETUP, in two halves, and the second is optional for now.
-  #   1. Settings -> Environments -> `nuget-org`, with required reviewers.  DONE.
-  #   2. A NUGET_API_KEY secret scoped to that environment.                 NOT YET.
+  # ONE-TIME SETUP, in two halves. BOTH ARE REQUIRED and each fails closed on its own.
   #
-  # WITHOUT THE KEY THIS JOB FAILS, ON PURPOSE, and prints the two commands to run by hand. A
-  # green "Publish to nuget.org" that pushed nothing is the false clearance this repository has
-  # been bitten by before; a red job that tells you exactly what to type is not. The release
-  # itself is unaffected — `release` has already packed, gated and published the GitHub Release
-  # by the time this job is even offered for approval.
+  #   1. GitHub: Settings -> Environments -> `nuget-org` -> tick "Required reviewers", name at
+  #      least one, and SAVE. Ticking without saving leaves `protection_rules: []`, and then a
+  #      tag publishes with nobody in the loop — which is the one thing this job exists to
+  #      prevent.
   #
-  # If nuget.org Trusted Publishing is available to this account, prefer it over the key: it
-  # authenticates this workflow by OIDC and removes the long-lived secret altogether. Verify
-  # before relying on it.
+  #   2. nuget.org: your username -> Trusted Publishing -> create a policy with
+  #        Repository Owner : azabluda
+  #        Repository       : InfoCarrier.Core
+  #        Workflow File    : release.yml      (file name only, no .github/workflows/ prefix)
+  #        Environment      : nuget-org        (optional, and worth setting: it pins the policy
+  #                                             to the approval-gated job rather than to any job
+  #                                             in this workflow)
+  #      The policy applies to every package owned by that account, so neither package has to
+  #      exist on nuget.org first — which matters here, because neither does.
+  #
+  # A NEW POLICY ON A PRIVATE REPOSITORY IS "PENDING" FOR 7 DAYS and goes inactive if nothing is
+  # published in that window; the first successful publish makes it permanent. This repository is
+  # public, so it should be active immediately — but check the status in the UI if a push is
+  # refused.
+  #
+  # WHY OIDC RATHER THAN A STORED KEY. The token is minted per run, is good for one exchange, and
+  # yields an API key valid for one hour. There is no secret to rotate, to leak, or to forget on a
+  # laptop. Request it immediately before the push, as below: asking early and pushing late is the
+  # documented way to have it expire under you.
   # ------------------------------------------------------------------------------------------
   publish-nuget:
     name: Publish to nuget.org
@@ -194,6 +201,13 @@ jobs:
     environment:
       name: nuget-org
       url: https://www.nuget.org/packages/InfoCarrier.Core
+
+    # `id-token: write` is what lets this job ask GitHub for the OIDC token nuget.org validates.
+    # Without it the login step fails with a token-issuance error rather than an auth error, which
+    # is worth knowing before diagnosing the wrong end.
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Download packages
@@ -207,31 +221,19 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      # Stop here, loudly, rather than letting `dotnet nuget push` fail with a message about
-      # authentication that says nothing about what to do. The packages are on the GitHub Release
-      # either way, so the manual route below is a copy-paste.
-      - name: Require a key
-        env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-        run: |
-          if [ -n "$NUGET_API_KEY" ]; then
-            echo "nuget-org carries a key; publishing."
-            exit 0
-          fi
-          V="${GITHUB_REF_NAME#v}"
-          echo "::error::The nuget-org environment has no NUGET_API_KEY, so nothing was pushed. Add one (Settings -> Environments -> nuget-org -> Add secret) to publish from CI, or push by hand from the packages attached to this release -- InfoCarrier.Core FIRST, because InfoCarrier.Core.AspNetCore depends on it and nuget.org rejects a package whose dependency does not resolve."
-          {
-            echo "### Publish $V by hand"
-            echo
-            echo '```bash'
-            echo "SRC=https://api.nuget.org/v3/index.json"
-            echo "dotnet nuget push \"InfoCarrier.Core.$V.nupkg\"            --source \$SRC --api-key \"\$KEY\""
-            echo "dotnet nuget push \"InfoCarrier.Core.AspNetCore.$V.nupkg\" --source \$SRC --api-key \"\$KEY\""
-            echo "dotnet nuget push \"InfoCarrier.Core.$V.snupkg\"           --source \$SRC --api-key \"\$KEY\""
-            echo "dotnet nuget push \"InfoCarrier.Core.AspNetCore.$V.snupkg\" --source \$SRC --api-key \"\$KEY\""
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
-          exit 1
+      # THE CREDENTIAL IS MINTED HERE, ONE STEP BEFORE IT IS USED. nuget.org exchanges this
+      # job's OIDC token for an API key valid for ONE HOUR, and each token buys exactly one key.
+      # Requesting it early and pushing late is the documented way to have it expire mid-release,
+      # so this sits immediately above the pushes and nowhere else.
+      #
+      # `user` is the nuget.org PROFILE NAME, not an email address. It is not a secret — it is
+      # already visible on every package page — so it is written plainly rather than hidden in a
+      # secret that would only make the failure harder to read.
+      - name: Exchange the OIDC token for a short-lived key
+        id: login
+        uses: NuGet/login@v1
+        with:
+          user: azabluda
 
       # ORDER MATTERS, and it is why this is two steps rather than a glob over the folder.
       # InfoCarrier.Core.AspNetCore declares a dependency on InfoCarrier.Core at the same
@@ -240,32 +242,23 @@ jobs:
       # EXACT FILENAMES, not globs: `InfoCarrier.Core.*.nupkg` also matches
       # InfoCarrier.Core.AspNetCore. A stale filter of exactly that shape is what broke the old
       # version gate, so the lesson is spent here rather than learned twice.
-      #
-      # The key travels as an environment variable rather than inline, so it never appears in a
-      # command line the runner echoes.
       - name: Push InfoCarrier.Core
-        env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         run: >
           dotnet nuget push "artifacts/pack/InfoCarrier.Core.${GITHUB_REF_NAME#v}.nupkg"
           --source https://api.nuget.org/v3/index.json
-          --api-key "$NUGET_API_KEY"
+          --api-key "${{ steps.login.outputs.NUGET_API_KEY }}"
 
       - name: Push InfoCarrier.Core.AspNetCore
-        env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         run: >
           dotnet nuget push "artifacts/pack/InfoCarrier.Core.AspNetCore.${GITHUB_REF_NAME#v}.nupkg"
           --source https://api.nuget.org/v3/index.json
-          --api-key "$NUGET_API_KEY"
+          --api-key "${{ steps.login.outputs.NUGET_API_KEY }}"
 
       # Symbols are a separate push and a non-fatal one: a failed symbol upload must not leave a
       # release half-published, and the packages themselves are already on the feed by here.
       - name: Push symbols
         continue-on-error: true
-        env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         run: |
           for id in InfoCarrier.Core InfoCarrier.Core.AspNetCore; do
-            dotnet nuget push "artifacts/pack/$id.${GITHUB_REF_NAME#v}.snupkg"               --source https://api.nuget.org/v3/index.json               --api-key "$NUGET_API_KEY"
+            dotnet nuget push "artifacts/pack/$id.${GITHUB_REF_NAME#v}.snupkg"               --source https://api.nuget.org/v3/index.json               --api-key "${{ steps.login.outputs.NUGET_API_KEY }}"
           done

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -60,9 +60,10 @@ it. On approval it pushes `InfoCarrier.Core`, then `InfoCarrier.Core.AspNetCore`
 packages — in that order, because the second declares a dependency on the first and nuget.org
 rejects a package whose dependency does not resolve.
 
-`NUGET_API_KEY` is a secret scoped to that environment, not a repository secret, so no workflow
-outside it can read the key. **It is not configured yet** — until it is, the job stops at its first
-step with the manual push commands in the run summary, having pushed nothing.
+**There is no publishing secret in this repository.** The job exchanges a GitHub OIDC token for a
+nuget.org API key valid for one hour (Trusted Publishing), so nothing long-lived is stored. It
+needs `id-token: write`, and a policy on nuget.org naming this owner, repository, workflow file and
+environment. See [`versioning.md`](versioning.md).
 
 ### `packages.yml` — the internal feed
 

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -1732,3 +1732,53 @@ rather than staying silent about it.
 
       **Gates: `mkdocs build --strict` green.** No `src/`, no `test/`; one line of theme
       configuration.
+
+- [x] **N15. Trusted Publishing: no publishing secret exists at all.** `<this commit>`
+
+      nuget.org's own account page now says it plainly: *"API keys are strongly discouraged for
+      automated publishing and should be replaced with Trusted Publishing."* N9 had priced that as
+      *"prefer it if available, verify before relying on it"* — it is available, so it is taken, and
+      the API-key route is gone rather than kept as a fallback. One path is easier to keep true
+      than two.
+
+      **What replaces the secret.** The job asks GitHub for an OIDC token; nuget.org validates it
+      against a policy naming owner, repository, workflow file and environment, and returns an API
+      key valid for **one hour**. Nothing long-lived is stored, so nothing long-lived can leak, be
+      rotated late, or sit forgotten on a laptop. `grep 'secrets.'` over `release.yml` now returns
+      **nothing**.
+
+      **Read from the vendor rather than remembered**, because the mechanism is newer than any
+      recollection worth trusting: `NuGet/login@v1` takes `user` (the nuget.org *profile name*, not
+      an email) and emits `NUGET_API_KEY` as a step output; the job needs `id-token: write`. Both
+      confirmed against the action's own repository and Microsoft's documentation before the
+      workflow was written.
+
+      **The exchange sits one step above the pushes, and that placement is load-bearing.** Each
+      token buys exactly one key, the key lives an hour, and asking early then pushing late is the
+      documented way to have it expire mid-release — with the first package published and the
+      second not.
+
+      **THE APPROVAL GATE DID NOT EXIST, and this is the finding of the step.** The `nuget-org`
+      environment was created, but the API says:
+
+      ```
+      protection_rules  : []
+      branch policy     : null
+      secrets           : 0
+      ```
+
+      **Required reviewers had been ticked but never saved.** With no key that was harmless — the
+      job stopped at its own guard. The moment a credential existed, a tag would have published to
+      nuget.org **unattended**, which is the single thing M8-20's rule exists to prevent. Found by
+      reading the environment over the API instead of trusting the UI, and the same lesson as
+      everything else today: *the setting you believe you made is not evidence.*
+
+      **Setup is now two halves that each fail closed**, written up in `versioning.md` with the
+      four policy fields and the exact `gh api` call that proves the reviewer stuck. Also recorded:
+      the policy covers **every package owned by the account**, so neither package has to exist on
+      nuget.org first — which is the question that would otherwise have been asked at the worst
+      moment, since neither does.
+
+      **Gates: `mkdocs build --strict` green; `release.yml` re-parsed** — `permissions
+      {contents: read, id-token: write}`, environment `nuget-org`, six steps in the intended order.
+      No `src/`, no `test/`.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -159,26 +159,47 @@ from their own machine with their own key. They now approve a protected environm
 the key is not on a laptop, the step is repeatable, and the push is recorded against the run that
 made it.
 
-**Setup, in two halves:**
+### There is no publishing secret
 
-| | Status |
+Publishing uses nuget.org's **Trusted Publishing**. The job asks GitHub for an OIDC token,
+nuget.org validates it against a policy naming this owner, repository, workflow file and
+environment, and returns an API key valid for **one hour**. Nothing long-lived is stored, so
+nothing long-lived can leak — and nuget.org's own guidance now calls API keys *"strongly
+discouraged"* for automated publishing.
+
+The exchange happens in the step immediately above the pushes, deliberately: each token buys
+exactly one key, and requesting it early then pushing late is the documented way to have it expire
+mid-release.
+
+**Setup, in two halves. Both are required, and each fails closed on its own.**
+
+| Where | What |
 |---|---|
-| *Settings → Environments → `nuget-org`*, with **Required reviewers** | done |
-| `NUGET_API_KEY`, scoped to that environment | not yet — first upload is by hand |
+| GitHub | *Settings → Environments → `nuget-org`* → tick **Required reviewers**, name at least one, and **Save**. |
+| nuget.org | *Your username → Trusted Publishing → Create*, with the four fields below. |
 
-**Without the key the job fails on purpose**, at its first step, having pushed nothing. It prints
-the four `dotnet nuget push` commands into the run summary, filled in with the version being
-released, and the Release body carries the same list. The release itself is unaffected: `release`
-has already packed, gated and published the GitHub Release before `publish-nuget` is even offered
-for approval.
+| Policy field | Value |
+|---|---|
+| Repository Owner | `azabluda` |
+| Repository | `InfoCarrier.Core` |
+| Workflow File | `release.yml` — **file name only**, no `.github/workflows/` prefix |
+| Environment | `nuget-org` — optional, and worth setting: it pins the policy to the approval-gated job rather than to any job in this workflow |
 
-**A green "Publish to nuget.org" that pushed nothing would be worse than a red one.** That is the
-false-clearance shape this repository has been bitten by before — a gate that passes for ever
-because it silently does nothing. A red job that tells you exactly what to type is not that.
+The policy covers **every package owned by that account**, so neither package has to exist on
+nuget.org first — which matters here, because neither does.
 
-If nuget.org **Trusted Publishing** is available to this account, prefer it over adding the key —
-it authenticates the workflow by OIDC and removes the long-lived secret entirely. Check its current
-status before relying on it.
+!!! warning "Tick *and* save the reviewer"
+
+    Ticking **Required reviewers** without saving leaves the environment with
+    `protection_rules: []`, and then a tag publishes with nobody in the loop. Checked over the API
+    rather than in the UI: `gh api repos/azabluda/InfoCarrier.Core/environments/nuget-org` must
+    show a non-empty `protection_rules`.
+
+!!! note "A new policy on a private repository is *pending* for 7 days"
+
+    It goes inactive if nothing is published in that window; the first successful publish makes it
+    permanent. This repository is public, so the policy should be active immediately — but check
+    the status in the nuget.org UI if a push is refused.
 
 ## Releasing, start to finish
 


### PR DESCRIPTION
## Why

nuget.org's own account page now says it: *"API keys are strongly discouraged for automated
publishing and should be replaced with Trusted Publishing."* N9 priced that as "prefer it if
available, verify first". It is available, so it is taken — and the API-key route is **removed**
rather than kept as a fallback. One path is easier to keep true than two.

## What changes

The job asks GitHub for an OIDC token; nuget.org validates it against a policy naming owner,
repository, workflow file and environment, and returns an API key valid for **one hour**.

- `grep 'secrets.'` over `release.yml` now returns **nothing**.
- `permissions: id-token: write` added to `publish-nuget`.
- The exchange sits **one step above** the pushes. Each token buys one key, the key lives an hour,
  and asking early then pushing late is the documented way to expire mid-release — with the first
  package published and the second not.

Written from the vendor's docs, not memory: `NuGet/login@v1` takes `user` (the nuget.org **profile
name**, not an email) and emits `NUGET_API_KEY` as a step output. Confirmed against the action's
repository and Microsoft Learn before the YAML was written.

## ⚠️ The finding: the approval gate did not exist

Reading the environment over the API rather than trusting the UI:

```
protection_rules  : []
branch policy     : null
secrets           : 0
```

**Required reviewers had been ticked but never saved.** With no credential that was harmless — the
job stopped at its own guard. **The moment a credential exists, a tag would publish to nuget.org
unattended**, which is the one thing M8-20's rule exists to prevent.

## Setup still required, both halves fail closed

| Where | What |
|---|---|
| GitHub | *Settings → Environments → `nuget-org`* → tick **Required reviewers**, name one, and **Save** |
| nuget.org | *Trusted Publishing → Create* — Owner `azabluda`, Repository `InfoCarrier.Core`, Workflow File `release.yml` (name only), Environment `nuget-org` |

A policy covers **every package owned by the account**, so neither package has to exist on
nuget.org first — which matters, because neither does.

## Verified

`mkdocs build --strict` green. `release.yml` re-parsed: permissions `{contents: read, id-token:
write}`, environment `nuget-org`, six steps in the intended order. No `src/`, no `test/`.