### PR TITLE
Fix install docs: an unversioned add gets InfoCarrier.Core 3.1.1, not this library

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ dotnet add package InfoCarrier.Core --version 10.0.0-preview.1              # th
 dotnet add package InfoCarrier.Core.AspNetCore --version 10.0.0-preview.1   # the server endpoint
 ```
 
-> ⚠️ **Name the version.** `InfoCarrier.Core` has been on nuget.org since v1, and its newest
-> *stable* release is **`3.1.1`** — the previous generation, built for EF Core 3.1. An unversioned
+> ⚠️ **Name the version.** `InfoCarrier.Core` has been on nuget.org since **1.0**, and its newest
+> *stable* release is **`3.1.1`** — the earlier line, built for EF Core 3.1. An unversioned
 > `dotnet add package InfoCarrier.Core` installs **that**, not this one, and will keep doing so
 > until a stable `10.x` ships. Name the version, or pass `--prerelease`.
 
@@ -173,17 +173,18 @@ dotnet run --project samples/Northwind.Demo
 See [`samples/README.md`](samples/README.md), which also records the two things WebAssembly will
 not do — and why neither is this provider's constraint.
 
-## How it differs from v1
+## How it differs from InfoCarrier.Core 1.0–3.1
 
-This is a **ground-up rewrite** of [InfoCarrier.Core v1](https://github.com/azabluda/InfoCarrier.Core)
-for EF Core 10, not a port.
+This is a **ground-up rewrite** of
+[InfoCarrier.Core 1.0–3.1](https://github.com/azabluda/InfoCarrier.Core/tree/master) for EF Core
+10, not a port. That line ran from `1.0` to `3.1.1` and targeted EF Core 1.x through 3.1.
 
 - **No Remote.Linq or Aqua dependency.** The expression serializer is in-tree and purpose-built,
   which is what makes the wire format, its type allowlist and its AOT story ours to reason about.
 - **A security boundary that is stated and tested.** Deserialization is default-deny across node
   kinds, types and methods, and the review behind it is
   [`docs/security-review.md`](docs/security-review.md) — including what is *accepted* and why.
-- **The EF specification suite is the acceptance criterion.** v1's stated failure mode was
+- **The EF specification suite is the acceptance criterion.** The earlier line's stated failure mode was
   suppressing tests; here a red test is information, skipping one to go green is forbidden, and
   the failure count is ratcheted in CI.
 - **Trimming and AOT are measured, not assumed.** The Blazor client publishes trimmed and runs.
@@ -250,10 +251,10 @@ read it before adding a `NoWarn`.
 
 - [Entity Framework Core](https://github.com/dotnet/efcore) by Microsoft — this provider is built
   on it and judged by its test suite.
-- [InfoCarrier.Core v1](https://github.com/azabluda/InfoCarrier.Core), by
+- [InfoCarrier.Core 1.0–3.1](https://github.com/azabluda/InfoCarrier.Core/tree/master), by
   [on/off it-solutions gmbh](http://www.onoff-it-solutions.info), which proved the idea.
 - [Remote.Linq](https://github.com/6bee/Remote.Linq) and
-  [aqua-core](https://github.com/6bee/aqua-core) by Christof Senn — v1's foundation, and
+  [aqua-core](https://github.com/6bee/aqua-core) by Christof Senn — that line's foundation, and
   specification material for this rewrite.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -88,8 +88,10 @@ dotnet add package InfoCarrier.Core --version 10.0.0-preview.1              # th
 dotnet add package InfoCarrier.Core.AspNetCore --version 10.0.0-preview.1   # the server endpoint
 ```
 
-Name the version — or pass `--prerelease`. Without either, NuGet looks for a stable release and
-there is not one yet.
+> ⚠️ **Name the version.** `InfoCarrier.Core` has been on nuget.org since v1, and its newest
+> *stable* release is **`3.1.1`** — the previous generation, built for EF Core 3.1. An unversioned
+> `dotnet add package InfoCarrier.Core` installs **that**, not this one, and will keep doing so
+> until a stable `10.x` ships. Name the version, or pass `--prerelease`.
 
 **Not yet done:** a shipped gRPC binding, and streaming results as `IAsyncEnumerable`. Both may
 change `IInfoCarrierTransport`, which is why the version still says `preview`.

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -2024,3 +2024,30 @@ rather than staying silent about it.
       and the docs are already written as though it has been.
 
       **Gates: `mkdocs build --strict` green.** Markdown only; no `src/`, no `test/`.
+
+- [x] **N17b. "v1" is wrong, not merely vague, and it appeared in every user-facing document.**
+      `<this commit>`
+
+      The earlier InfoCarrier.Core is called **"v1"** throughout, and the published record says
+      otherwise: nuget.org carries `1.0.0-beta0002` through **`3.1.1`**, and this repository still
+      has `release/2.2`, `release/3.1` and `release/5.0` branches. Calling that "v1" understates it
+      by two majors, and it matters precisely where N17 landed: a reader told the old line is "v1"
+      has no reason to expect an unversioned install to hand them **3.1.1**.
+
+      Replaced with the span — **InfoCarrier.Core 1.0–3.1** on first mention, *"the earlier line"*
+      as shorthand — in `README.md` (five places, including the *How it differs from* heading),
+      `docs/nuget-readme.md`, and the site's installation and home pages. `grep -n '\bv1\b'` over
+      the user-facing set now returns nothing.
+
+      **The old links were pointed somewhere real while renaming them.** They said
+      `github.com/azabluda/InfoCarrier.Core` — which is *this* repository, whose default branch is
+      now `main` and therefore the **new** product, so a reader clicking "the previous version"
+      landed on the current one. They now name `/tree/master`, checked and answering 200.
+
+      **Internal documents are deliberately untouched.** `implementation-plan.md`, `roadmap.md`,
+      `decisions.md` and `architecture.md` use "v1" as a term of art hundreds of times, and their
+      audience is this repository. The instruction was about user-facing text and the split is the
+      same one Phase N is built on.
+
+      **Gates: `mkdocs build --strict` green**, no inbound anchor to the renamed README heading,
+      and the retargeted link verified. Markdown only.

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -1988,3 +1988,39 @@ rather than staying silent about it.
       For a 128px icon that no longer matters; for anything large it would.
 
       **Gates: `dotnet pack` clean.** No `src/` code, no `test/`.
+- [x] **N17. `dotnet add package InfoCarrier.Core` installs v1, and four pages said it would fail.**
+      `<this commit>`
+
+      N7 wrote every install instruction around one sentence: *"Without either, NuGet looks for a
+      stable release and there is not one yet."* **There is one.** `InfoCarrier.Core` has been on
+      nuget.org since v1 and its newest stable release is **`3.1.1`**, built for **EF Core 3.1**.
+
+      ```
+      2.1.1  2.1.4  2.2.0  2.2.1  2.2.6  2.2.7  3.1.0  3.1.1
+      ```
+
+      **The failure mode is the opposite of what was documented, and worse.** An unversioned
+      `dotnet add package InfoCarrier.Core` does not fail to find anything — it **succeeds**,
+      silently installing a library seven EF majors old. NuGet prefers a stable release over a
+      prerelease, so this stays true until a stable `10.x` ships, however many previews come first.
+      A reader following our own instructions verbatim would have hit it.
+
+      **The two packages are asymmetric**, which nothing said either: `InfoCarrier.Core.AspNetCore`
+      is new to this generation and returns 404, so for *that* one an unversioned install really
+      does find nothing. Same command, two different wrong outcomes.
+
+      Corrected on all four pages — `README.md`, `docs/nuget-readme.md`, the site's installation
+      page and its home page — and the site's version is a `danger` admonition showing the three
+      commands side by side, because "it installs the wrong thing without warning you" is not a tip.
+
+      **How it was found is the part worth keeping.** It came out of *cleanup verification* after
+      the release was rejected: a `curl` against nuget.org to confirm nothing had been published.
+      `InfoCarrier.Core` answered **HTTP 200**. The check was written to prove an absence and
+      discovered a presence — the docs bug was a free side effect of not trusting "nothing was
+      published" without asking.
+
+      **The README badge is affected too** and is left alone deliberately: `nuget/vpre` currently
+      renders `3.1.1`, v1's version. It becomes correct the moment `10.0.0-preview.1` is pushed,
+      and the docs are already written as though it has been.
+
+      **Gates: `mkdocs build --strict` green.** Markdown only; no `src/`, no `test/`.

--- a/docs/nuget-readme.md
+++ b/docs/nuget-readme.md
@@ -57,8 +57,8 @@ dotnet add package InfoCarrier.Core --version 10.0.0-preview.1              # th
 dotnet add package InfoCarrier.Core.AspNetCore --version 10.0.0-preview.1   # the server endpoint
 ```
 
-**Name the version.** `InfoCarrier.Core` has been on nuget.org since v1, and its newest *stable*
-release is **`3.1.1`** — the previous generation, built for EF Core 3.1. An unversioned
+**Name the version.** `InfoCarrier.Core` has been on nuget.org since **1.0**, and its newest
+*stable* release is **`3.1.1`** — the earlier line, built for EF Core 3.1. An unversioned
 `dotnet add package InfoCarrier.Core` installs that one, not this one, and will keep doing so until
 a stable `10.x` ships. Passing `--prerelease` works too.
 

--- a/docs/nuget-readme.md
+++ b/docs/nuget-readme.md
@@ -57,8 +57,13 @@ dotnet add package InfoCarrier.Core --version 10.0.0-preview.1              # th
 dotnet add package InfoCarrier.Core.AspNetCore --version 10.0.0-preview.1   # the server endpoint
 ```
 
-**Name the version, or pass `--prerelease`.** Without either, NuGet looks for a stable release and
-there is not one yet.
+**Name the version.** `InfoCarrier.Core` has been on nuget.org since v1, and its newest *stable*
+release is **`3.1.1`** — the previous generation, built for EF Core 3.1. An unversioned
+`dotnet add package InfoCarrier.Core` installs that one, not this one, and will keep doing so until
+a stable `10.x` ships. Passing `--prerelease` works too.
+
+`InfoCarrier.Core.AspNetCore` is new in this generation, so it has no older version to fall back
+to — but pin it anyway, so the two halves cannot drift apart.
 
 Both packages ship symbols and SourceLink, so you can step into the provider from a debugger.
 

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -53,14 +53,25 @@ the same code, which is what makes the wire format meaningful — see
     Install-Package InfoCarrier.Core.AspNetCore -Version 10.0.0-preview.1
     ```
 
-!!! tip "Name the version, or pass `--prerelease`"
+!!! danger "Always name the version — an unversioned install gets the *previous generation*"
+
+    `InfoCarrier.Core` has been on nuget.org since v1, and its newest **stable** release is
+    `3.1.1`, built for **EF Core 3.1**. NuGet prefers a stable release over a prerelease, so:
 
     ```bash
-    dotnet add package InfoCarrier.Core --prerelease
+    dotnet add package InfoCarrier.Core              # installs 3.1.1 — NOT this library
+    dotnet add package InfoCarrier.Core --version 10.0.0-preview.1   # correct
+    dotnet add package InfoCarrier.Core --prerelease                 # also correct
     ```
 
-    Without one or the other, NuGet looks for a stable release and there is not one yet. The same
-    applies to Central Package Management: pin `10.0.0-preview.1` in `Directory.Packages.props`.
+    It does not fail, and it does not warn. You get a different, incompatible library that targets
+    an EF Core seven majors old. This stays true until a stable `10.x` ships.
+
+    `InfoCarrier.Core.AspNetCore` is new in this generation and has no older version to fall back
+    to — but pin it anyway, so the two halves cannot drift apart.
+
+    The same applies to Central Package Management: pin `10.0.0-preview.1` in
+    `Directory.Packages.props`.
 
 Both packages ship symbol packages and SourceLink, so you can step into the provider from a
 debugger with no extra configuration.

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -55,7 +55,7 @@ the same code, which is what makes the wire format meaningful — see
 
 !!! danger "Always name the version — an unversioned install gets the *previous generation*"
 
-    `InfoCarrier.Core` has been on nuget.org since v1, and its newest **stable** release is
+    `InfoCarrier.Core` has been on nuget.org since **1.0**, and its newest **stable** release is
     `3.1.1`, built for **EF Core 3.1**. NuGet prefers a stable release over a prerelease, so:
 
     ```bash

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -96,9 +96,9 @@ The nine are known, and every one of them is written up on the
     dotnet add package InfoCarrier.Core --version 10.0.0-preview.1
     ```
 
-    **Name the version.** `InfoCarrier.Core` has been on nuget.org since v1, and an unversioned
-    install resolves to its newest *stable* release — `3.1.1`, built for EF Core 3.1 — rather than
-    to this one. See [Installation](getting-started/installation.md).
+    **Name the version.** `InfoCarrier.Core` has been on nuget.org since **1.0**, and an
+    unversioned install resolves to its newest *stable* release — `3.1.1`, built for EF Core 3.1 —
+    rather than to this one. See [Installation](getting-started/installation.md).
 
     A gRPC binding and streaming results as `IAsyncEnumerable` are still to come, and both may
     change the transport interface.

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -96,9 +96,12 @@ The nine are known, and every one of them is written up on the
     dotnet add package InfoCarrier.Core --version 10.0.0-preview.1
     ```
 
-    `10.0.0-preview.1` is the current version, so name it or pass `--prerelease` — there is no
-    stable release yet. A gRPC binding and streaming results as `IAsyncEnumerable` are still to
-    come, and both may change the transport interface.
+    **Name the version.** `InfoCarrier.Core` has been on nuget.org since v1, and an unversioned
+    install resolves to its newest *stable* release — `3.1.1`, built for EF Core 3.1 — rather than
+    to this one. See [Installation](getting-started/installation.md).
+
+    A gRPC binding and streaming results as `IAsyncEnumerable` are still to come, and both may
+    change the transport interface.
 
 ## Security in one paragraph
 


### PR DESCRIPTION
Two related corrections about how the **earlier** InfoCarrier.Core is described.

## 1. An unversioned install silently gets the old library

Four pages carried this sentence:

> *"Without either, NuGet looks for a stable release and there is not one yet."*

**There is one.** nuget.org carries `InfoCarrier.Core` from `1.0.0-beta0002` through **`3.1.1`** —
built for **EF Core 3.1**. NuGet prefers a stable release over a prerelease, so:

```bash
dotnet add package InfoCarrier.Core     # installs 3.1.1 — a different, incompatible library
```

**It does not fail and it does not warn.** The documented failure mode is the opposite of the real
one, and the real one is worse: a reader following our own instructions gets a library seven EF
majors old. True until a stable `10.x` ships, however many previews come first.

**The two packages behave differently**, which nothing said: `InfoCarrier.Core.AspNetCore` is new
to this generation and returns **404**, so for that one an unversioned install really does find
nothing.

## 2. "v1" is wrong, not just vague

The old line is called **"v1"** throughout, but it ran to **3.1.1** — two majors beyond that — and
this repository still carries `release/2.2`, `release/3.1` and `release/5.0`. The wrong name feeds
straight into the bug above: a reader told the old line is "v1" has no reason to expect an
unversioned install to hand them `3.1.1`.

Replaced with the span — **InfoCarrier.Core 1.0–3.1** on first mention, *"the earlier line"* as
shorthand. `grep '\bv1\b'` over the user-facing set now returns nothing.

**The links pointing at it were broken in a quieter way.** They named
`github.com/azabluda/InfoCarrier.Core` — *this* repository, whose default branch is now `main` and
therefore the **new** product. Clicking "the previous version" landed you on the current one. They
now name `/tree/master`, verified 200.

## Changed

| File | |
|---|---|
| `README.md` | warning block naming `3.1.1`; five "v1" replacements incl. the *How it differs from* heading |
| `docs/nuget-readme.md` | same, plus the asymmetry between the two packages |
| `website/.../installation.md` | a **danger** admonition with the three commands side by side |
| `website/docs/index.md` | preview note corrected, links to the installation page |

The site's version is `danger` rather than `tip` — "it installs the wrong thing without warning
you" is not a tip.

## How it was found

Cleanup verification after the rejected release: a `curl` against nuget.org to confirm nothing had
been published. `InfoCarrier.Core` answered **HTTP 200**. The check was written to prove an absence
and found a presence.

## Left alone deliberately

- The README's `nuget/vpre` badge renders `3.1.1` today. It becomes correct once
  `10.0.0-preview.1` is pushed, and the docs are already written as though it has been.
- Internal documents (`implementation-plan.md`, `roadmap.md`, `decisions.md`, `architecture.md`)
  keep "v1" as a term of art — their audience is this repository.

## Gates

`mkdocs build --strict` green; no inbound anchor to the renamed README heading; retargeted link
verified. Markdown only — no `src/`, no `test/`.
