### PR TITLE
Remove the redundant symbols push; record what the first release did

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,11 +254,14 @@ jobs:
           --source https://api.nuget.org/v3/index.json
           --api-key "${{ steps.login.outputs.NUGET_API_KEY }}"
 
-      # Symbols are a separate push and a non-fatal one: a failed symbol upload must not leave a
-      # release half-published, and the packages themselves are already on the feed by here.
-      - name: Push symbols
-        continue-on-error: true
-        run: |
-          for id in InfoCarrier.Core InfoCarrier.Core.AspNetCore; do
-            dotnet nuget push "artifacts/pack/$id.${GITHUB_REF_NAME#v}.snupkg"               --source https://api.nuget.org/v3/index.json               --api-key "${{ steps.login.outputs.NUGET_API_KEY }}"
-          done
+      # THERE IS NO SEPARATE SYMBOLS STEP, and there used to be. `dotnet nuget push` uploads the
+      # matching `.snupkg` by itself when it sits beside the `.nupkg`, which both pushes above do
+      # -- the run log shows four uploads from two commands:
+      #
+      #     Pushing InfoCarrier.Core.10.0.0-preview.1.nupkg  ... Your package was pushed.
+      #     Pushing InfoCarrier.Core.10.0.0-preview.1.snupkg ... Your package was pushed.
+      #
+      # A third step pushing the .snupkg files again earned a 409 from nuget.org ("another copy of
+      # this symbols package pending validation") on the very first real release. It was
+      # `continue-on-error`, so nothing broke -- it just printed a red annotation on an otherwise
+      # clean release, which is the kind of noise that teaches people to ignore annotations.

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -2080,3 +2080,34 @@ rather than staying silent about it.
       alone would leave the next person exactly where this phase started.
 
       **Gates: `dotnet pack` clean.** No `src/` code, no `test/`.
+
+- [x] **N19. The first real release, and the one thing that went wrong was ours.** `<this commit>`
+
+      **`10.0.0-preview.1` is published.** `InfoCarrier.Core` gained its first `10.x`;
+      `InfoCarrier.Core.AspNetCore` its first version ever. Verified against nuget.org rather than
+      against the run: both package pages answer `200`, both shields badges now render
+      `v10.0.0-preview.1` — Core's rendered `3.1.1` an hour ago — and the published `.nupkg`
+      contains `icon.png` (16,842 bytes) and the corrected `README.md`.
+
+      **Trusted Publishing worked on its first execution.** `Successfully exchanged OIDC token for
+      NuGet API key`, and no publishing secret exists anywhere in this repository. N15 built it
+      untested; this is the run that made it a fact.
+
+      **The failure was a step that should never have existed.** `dotnet nuget push` uploads the
+      matching `.snupkg` whenever it sits beside the `.nupkg` — two commands, four uploads, visible
+      in the log. A third step pushing the symbol packages *again* took a `409` from nuget.org
+      (*"another copy of this symbols package pending validation"*).
+
+      **Its reasoning was sound and its premise was false.** N9 wrote it so "a failed symbol upload
+      must not leave a release half-published" — true, and there was nothing left to upload. It was
+      `continue-on-error`, so nothing broke; what it produced was a **red annotation on a wholly
+      successful release**, which is precisely the noise that trains people to stop reading
+      annotations. Removed, with the log excerpt in the workflow so nobody re-adds it.
+
+      `docs/versioning.md` gains *"What the first release actually did"* — the gate figures, the
+      OIDC line, four uploads from two commands, and the standing consequence that `3.1.1` is still
+      the latest **stable**, so an unversioned install keeps resolving to the EF Core 3.1 line until
+      a stable `10.x` ships.
+
+      **Gates: `mkdocs build --strict` green; `release.yml` re-parsed** — five steps, in order, no
+      symbols step. No `src/`, no `test/`.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -146,12 +146,36 @@ dotnet add package InfoCarrier.Core --prerelease
 ### nuget.org
 
 Pushing a tag runs the gates, packs, and creates the Release. The `publish-nuget` job then **stops
-and waits for a reviewer**. Approve it and it pushes `InfoCarrier.Core` first, then
-`InfoCarrier.Core.AspNetCore`, then the symbol packages.
+and waits for a reviewer**. Approve it and it pushes `InfoCarrier.Core`, then
+`InfoCarrier.Core.AspNetCore`.
 
 The order is not cosmetic: `InfoCarrier.Core.AspNetCore` declares a dependency on
 `InfoCarrier.Core` at the same version, and nuget.org rejects a package whose dependency does not
 resolve.
+
+**Symbols need no step of their own.** `dotnet nuget push` uploads the matching `.snupkg` whenever
+it sits beside the `.nupkg`, so two commands produce four uploads.
+
+### What the first release actually did
+
+`10.0.0-preview.1`, 2026-08-18, and it is recorded because a mechanism that has never run is a
+design rather than a fact:
+
+| | |
+|---|---|
+| Gates before packing | `22658` tests, `9` failing — the baseline — and `trim-ratchet: OK (88 <= 88)` |
+| Trusted Publishing | `Successfully exchanged OIDC token for NuGet API key` — worked on its first execution, no key anywhere |
+| Uploads | four, from two `dotnet nuget push` commands |
+| Result | both packages live; `InfoCarrier.Core` gained its first `10.x`, `InfoCarrier.Core.AspNetCore` its first version ever |
+
+**One thing went wrong and it was ours.** A third step pushed the `.snupkg` files a second time and
+took a `409` — *"another copy of this symbols package pending validation"*. It was
+`continue-on-error`, so the release completed, but it printed a failure annotation on a successful
+run. The step is gone.
+
+**And the thing to keep watching:** `3.1.1` is still the latest *stable*, so
+`dotnet add package InfoCarrier.Core` with no version continues to resolve to the EF Core 3.1 line.
+That stays true until a stable `10.x` ships.
 
 **M8-20's rule is intact — a person still decides, because a pushed version can be unlisted but
 never withdrawn.** What changed is where that person stands. They used to run `dotnet nuget push`


### PR DESCRIPTION
## The glitch on the first real release

```
Successfully exchanged OIDC token for NuGet API key.
Pushing InfoCarrier.Core.10.0.0-preview.1.nupkg   … Your package was pushed.
Pushing InfoCarrier.Core.10.0.0-preview.1.snupkg  … Your package was pushed.   ← automatic
Pushing InfoCarrier.Core.AspNetCore….nupkg        … Your package was pushed.
Pushing InfoCarrier.Core.AspNetCore….snupkg       … Your package was pushed.   ← automatic

error: 409 (It looks like there is another copy of this symbols package pending validation)
```

**`dotnet nuget push` uploads the matching `.snupkg` whenever it sits beside the `.nupkg`** — two
commands, four uploads. A third step pushed the symbol packages *again* and took a 409.

Its reasoning was sound and its premise false: it existed so "a failed symbol upload must not leave
a release half-published" — true, and there was nothing left to upload. `continue-on-error` meant
nothing broke; what it produced was a **red annotation on a wholly successful release**, which is
the noise that trains people to stop reading annotations.

Removed, with the log excerpt kept in the workflow so nobody re-adds it.

## What shipped, verified against nuget.org rather than the run

| | |
|---|---|
| `InfoCarrier.Core` | first `10.x` — page `200` |
| `InfoCarrier.Core.AspNetCore` | first version ever — page `200` |
| Badges | both now render `v10.0.0-preview.1`; Core's rendered `3.1.1` an hour ago |
| Published `.nupkg` | contains `icon.png` (16,842 bytes) and the corrected `README.md` |
| Trusted Publishing | worked on its **first** execution; no publishing secret exists in this repo |
| Gates before packing | `22658` tests, `9` failing (baseline); `trim-ratchet: OK (88 <= 88)` |

## Also

`docs/versioning.md` gains **"What the first release actually did"** — a mechanism that has never
run is a design, not a fact. It records the gate figures, the OIDC line, four uploads from two
commands, and the standing consequence: **`3.1.1` is still the latest *stable***, so an unversioned
install keeps resolving to the EF Core 3.1 line until a stable `10.x` ships.

## Gates

`mkdocs build --strict` green; `release.yml` re-parsed — five steps, in order, no symbols step.
No `src/`, no `test/`.