### PR TITLE
Correct a stale trim number, record the runner flake, gate project XML

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,13 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
+      # Before restore, because a malformed project file does not announce itself as one: it
+      # surfaced once as `NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher`, which
+      # names trimming and means "no usable TargetFramework". One second, and the failure names the
+      # file and the line.
+      - name: Check project XML
+        run: bash eng/check-project-xml.sh
+
       - name: Restore
         run: dotnet restore ${{ env.SOLUTION }}
 
@@ -84,6 +91,13 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      # Before restore, because a malformed project file does not announce itself as one: it
+      # surfaced once as `NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher`, which
+      # names trimming and means "no usable TargetFramework". One second, and the failure names the
+      # file and the line.
+      - name: Check project XML
+        run: bash eng/check-project-xml.sh
 
       - name: Restore
         run: dotnet restore ${{ env.SOLUTION }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ not explain:
 |---|---|
 | `eng/measure.sh <label> [baseline]` | The way to measure a change. See below. |
 | `eng/ratchet.sh <results.trx> <baseline-file>` | **CI only**, and wired: `.github/workflows/build.yml`'s *spec-ratchet* job invokes it against `test/known-failures.txt`. The suite is legitimately red during build-out and tests must not be skipped to force it green, so CI gates on the *direction* of the failure count. It guards the **total** as well: a crashed host reports fewer failures because fewer tests ran, which once came within one measurement of looking like an improvement. **The baseline is read out of the TRX, never out of the console block and never by arithmetic** — the TRX is what this script parses, and its `total` counts the skips its `passed` and `failed` do not. |
+| `eng/check-project-xml.sh` | Parses every `.csproj`/`.props`/`.targets` as XML, in about a second. **Wired into both `build.yml` jobs, before restore.** A malformed project file does not announce itself: it once surfaced as `NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher`, which names trimming and actually means "no usable TargetFramework" — and the same error had appeared before from a stale `obj/Release`, so its own history misleads. Both real cases were a **double hyphen inside an XML comment**, which is illegal and very easy to write while documenting a command: `<!-- dotnet build --configuration Release -->`. Use `-c Release`. |
 | `eng/gate.sh` | A detached delay used to schedule an unattended session. Sleeps 7200s, then writes `artifacts/gate-open.txt`. Not part of the build; delete it if it stops being useful. |
 
 **Measuring a change: `eng/measure.sh <label> [baseline]`** (or the `/experiment` skill, which
@@ -351,7 +352,7 @@ Not yet implemented, in rough priority order:
     which is the silent-divergence shape A49/B4/B12 warn about. **A one-GUID regeneration diff is
     the tell that the factory was never consulted**, and it was misread once as "proxies do not
     affect the model". The compiled model is removed; the sample builds its model at start-up.
-  - **Trimming: 86 IL warnings are ours and spec §9's "none of ours" criterion is NOT met.** They
+  - **Trimming: 88 IL warnings are ours and spec §9's "none of ours" criterion is NOT met.** They
     are the premise showing through — the wire carries a type's *name* — so
     `[DynamicallyAccessedMembers]` cannot express them. Gated by direction in `eng/trim-ratchet.sh`
     against `eng/trim-baseline.txt`, exactly as `eng/ratchet.sh` gates the spec suite. **The app
@@ -360,7 +361,11 @@ Not yet implemented, in rough priority order:
     ILLink, and the script's first version reported `OURS: 0` — a gate that would have passed
     forever. It now wipes `obj/Release` and refuses a log with no ILLink banner. **And classify
     trim warnings by declaring member, never by file path: this repository's own path contains the
-    string "InfoCarrier", so a naive grep attributes all 1129 to this product.**
+    string "InfoCarrier", so a naive grep attributes every warning in the log to this product.**
+    (The totals move for reasons that are not ours: `ours` went 86 → 88 for a deliberate
+    `WireGrouping` fix, and `total` fell 1129 → 853 when EF Core's own count dropped. Read the
+    current pair out of `eng/trim-baseline.txt`; it records every measurement and why each moved,
+    which is why no number is quoted here.)
 - **Complex types work** (A32) — `ComplexTypesTrackingTestBase` is **249 of 251**, and the two
   left are one shape of one feature: a property-bag complex *collection* on an `Added` entity.
   A complex value cannot ride in the value dictionary an entity is built from — `CreateEntry` and
@@ -664,6 +669,15 @@ was expected to print.
 **The suite is deterministic. Run it once.** Do not re-run to "confirm" a result — `measure.sh`
 already ran it, and repeating that is minutes of wall clock buying nothing. Flakiness is not the
 default assumption.
+
+**One sighting on record, 2026-08-18, and it was the runner rather than this repository.** A
+`Build & Test` run on `main` reported `Total: 11308` against a baseline of `22658` — the host
+crashed mid-`NorthwindJoinQuerySqlite` with `Test host process crashed` and no exception. **The
+ratchet caught it on the total, which is what that guard is for**: failures had "fallen" 9 → 3, and
+without the total check it would have read as the best result of the day. Re-running the same job
+on the same commit gave `22658 / 22472 / 9 / 177`. The commit changed only `release.yml` and
+Markdown, so nothing test-affecting differed between the two runs. Not chased further; if it
+recurs, it is the top priority and the rule below applies.
 
 **If you do notice flakiness, it becomes the top priority — before whatever you were doing.** The
 signal is a run that differs from the previous snapshot with **no code change between them**;

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -2080,3 +2080,39 @@ rather than staying silent about it.
       alone would leave the next person exactly where this phase started.
 
       **Gates: `dotnet pack` clean.** No `src/` code, no `test/`.
+
+- [x] **N20. Three leftovers: a stale number, an unrecorded flake, and a gate for the bug that got
+      through twice.** `<this commit>`
+
+      **`CLAUDE.md` said 86 IL warnings; `eng/trim-baseline.txt` says 88**, and has since J8's
+      deliberate `WireGrouping` rise. Corrected — and the companion sentence that quoted `1129` now
+      quotes nothing at all, because `total` has since fallen to 853 for reasons that are **not
+      ours** (EF Core's own count dropped). A number copied into prose goes stale silently; the
+      baseline file records every measurement *and why it moved*, so the prose points there.
+
+      **The flake is on record.** A `Build & Test` run on `main` reported `Total: 11308` against a
+      baseline of `22658` — `Test host process crashed`, no exception, mid-`NorthwindJoinQuerySqlite`.
+      **The ratchet caught it on the total**, which is exactly what that guard exists for: failures
+      had "fallen" 9 → 3 and would otherwise have read as the best result of the day. Re-running the
+      same job on the same commit gave `22658 / 22472 / 9 / 177`, and the commit changed only
+      `release.yml` and Markdown — nothing test-affecting differed between them. Written up beside
+      the flakiness rule so a second sighting has something to be a second sighting *of*.
+
+      **`eng/check-project-xml.sh`, wired into both `build.yml` jobs before restore.** Two of three
+      CI failures in one afternoon were a malformed project file, and neither said so — one arrived
+      as `NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher`, which names trimming
+      and means *"no usable TargetFramework"*. Both were a **double hyphen inside an XML comment**,
+      illegal and very easy to write while documenting a command.
+
+      **The check was made to fail before it was trusted.** Reintroducing the exact N13 bug produced
+      `not well-formed (invalid token): line 168, column 50` and exit 1; removing it produced
+      `OK (10 files parsed)`.
+
+      **And its first run found a bug in itself.** It called `python3`, which on Windows resolves to
+      a Microsoft Store stub that exists on `PATH` and then refuses to run — so it reported **all
+      ten** project files malformed. `command -v` proves a name resolves, not that it executes; the
+      script now tries `python3`, `python`, `py` and keeps the first that survives `-c "pass"`.
+      **A gate that cannot be run locally is the problem it was written to fix.**
+
+      **Gates: `eng/check-project-xml.sh` OK; `CI=true dotnet build -c Release` → `0 Error(s)`.**
+      No `src/` code, no `test/`.

--- a/eng/check-project-xml.sh
+++ b/eng/check-project-xml.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Parse every MSBuild project file as XML, and fail if any of them is malformed.
+#
+# WHY THIS EXISTS. Two of the three CI failures in one afternoon were a malformed project file, and
+# neither said so. The second one reported:
+#
+#     error NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher
+#
+# which names trimming and has nothing to do with trimming: `Directory.Build.props` would not
+# parse, so there was no TargetFramework for the check to be satisfied by, and that is what MSBuild
+# says when it finds none. The same error had appeared once before from a completely different
+# cause (a stale obj/Release), so its own history is misleading too.
+#
+# THE CAUSE BOTH TIMES WAS A DOUBLE HYPHEN INSIDE AN XML COMMENT. `--` is illegal there, and it is
+# very easy to write while documenting a command:
+#
+#     <!-- CI=true dotnet build InfoCarrier.Core.slnx --configuration Release -->
+#
+# That is a comment explaining how to keep CI green, and it is what turned CI red. Use `-c Release`.
+#
+# This runs in about a second, before restore, so the failure names the file and the line instead
+# of arriving later disguised as an SDK error.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Pick an interpreter that actually RUNS, rather than one that merely resolves. On Windows,
+# `python3` resolves to a Microsoft Store stub that exists on PATH and then refuses to execute --
+# so `command -v` is not enough, and trusting it made this script report all ten project files
+# malformed on its first run. A gate that cannot be run locally is the problem it exists to fix.
+PY=""
+for candidate in python3 python py; do
+  if command -v "$candidate" >/dev/null 2>&1 && "$candidate" -c "pass" >/dev/null 2>&1; then
+    PY="$candidate"
+    break
+  fi
+done
+
+if [ -z "$PY" ]; then
+  echo "check-project-xml: no working Python found (tried python3, python, py); skipping." >&2
+  exit 0
+fi
+
+failed=0
+count=0
+
+# Everything MSBuild reads as XML. `obj/` and `bin/` hold generated copies; skip them.
+while IFS= read -r file; do
+  count=$((count + 1))
+  if ! error=$("$PY" -c "
+import sys, xml.etree.ElementTree as ET
+try:
+    ET.parse(sys.argv[1])
+except Exception as e:
+    print(e); sys.exit(1)
+" "$file" 2>&1); then
+    echo "::error file=$file::Malformed XML: $error"
+    echo "  INVALID  $file"
+    echo "           $error"
+    failed=$((failed + 1))
+  fi
+done < <(find . \
+  \( -path ./subrepos -o -path ./artifacts -o -name obj -o -name bin \) -prune -o \
+  \( -name '*.csproj' -o -name '*.props' -o -name '*.targets' \) -print)
+
+if [ "$failed" -gt 0 ]; then
+  echo "check-project-xml: $failed of $count project files are malformed."
+  exit 1
+fi
+
+echo "check-project-xml: OK ($count files parsed)."


### PR DESCRIPTION
The three leftovers, together because each is small and none is worth its own review.

## 1. `CLAUDE.md` said 86 IL warnings; the baseline says 88

Stale since J8's deliberate `WireGrouping` rise. Corrected — and the companion sentence that quoted
`1129` now quotes **nothing**, because `total` has since fallen to `853` for reasons that are *not
ours* (EF Core's own count dropped). A number copied into prose goes stale silently;
`eng/trim-baseline.txt` records every measurement **and why it moved**, so the prose points there.

## 2. The runner flake is on record

A `Build & Test` run on `main` reported `Total: 11308` against a baseline of `22658` —
`Test host process crashed`, no exception, mid-`NorthwindJoinQuerySqlite`.

**The ratchet caught it on the total**, which is exactly what that guard is for: failures had
"fallen" 9 → 3 and would otherwise have read as the best result of the day. Re-running the same job
on the same commit gave `22658 / 22472 / 9 / 177`, and that commit changed only `release.yml` and
Markdown — nothing test-affecting differed between the two runs.

Not chased further. Written up beside the flakiness rule so a second sighting has something to be a
second sighting *of*.

## 3. `eng/check-project-xml.sh`, in both `build.yml` jobs, before restore

Two of three CI failures in one afternoon were a malformed project file, and **neither said so**.
One arrived as:

```
error NETSDK1124: Trimming assemblies requires .NET Core 3.0 or higher
```

which names trimming and actually means *"no usable TargetFramework"* — and the same error had
appeared before from a stale `obj/Release`, so its own history misleads. Both real cases were a
**double hyphen inside an XML comment**, illegal and very easy to write while documenting a
command:

```xml
<!-- CI=true dotnet build InfoCarrier.Core.slnx --configuration Release -->
```

**Made to fail before being trusted.** Reintroducing the exact bug produced
`not well-formed (invalid token): line 168, column 50` and exit 1; removing it produced
`OK (10 files parsed)`.

**Its first run found a bug in itself.** It called `python3` — which on Windows resolves to a
Microsoft Store stub that exists on `PATH` and then refuses to execute — so it reported **all ten**
project files malformed. `command -v` proves a name resolves, not that it runs. It now tries
`python3`, `python`, `py` and keeps the first that survives `-c "pass"`. *A gate that cannot be run
locally is the problem it was written to fix.*

## Gates

`eng/check-project-xml.sh` OK (10 files); `CI=true dotnet build -c Release` → `0 Error(s)`.
No `src/` code, no `test/`.