### PR TITLE
CLAUDE.md: correct a trim count, and stop quoting the other one

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,7 +351,7 @@ Not yet implemented, in rough priority order:
     which is the silent-divergence shape A49/B4/B12 warn about. **A one-GUID regeneration diff is
     the tell that the factory was never consulted**, and it was misread once as "proxies do not
     affect the model". The compiled model is removed; the sample builds its model at start-up.
-  - **Trimming: 86 IL warnings are ours and spec §9's "none of ours" criterion is NOT met.** They
+  - **Trimming: 88 IL warnings are ours and spec §9's "none of ours" criterion is NOT met.** They
     are the premise showing through — the wire carries a type's *name* — so
     `[DynamicallyAccessedMembers]` cannot express them. Gated by direction in `eng/trim-ratchet.sh`
     against `eng/trim-baseline.txt`, exactly as `eng/ratchet.sh` gates the spec suite. **The app
@@ -360,7 +360,12 @@ Not yet implemented, in rough priority order:
     ILLink, and the script's first version reported `OURS: 0` — a gate that would have passed
     forever. It now wipes `obj/Release` and refuses a log with no ILLink banner. **And classify
     trim warnings by declaring member, never by file path: this repository's own path contains the
-    string "InfoCarrier", so a naive grep attributes all 1129 to this product.**
+    string "InfoCarrier", so a naive grep attributes every warning in the log to this product.**
+    **No count is quoted here on purpose — read `ours` and `total` out of `eng/trim-baseline.txt`.**
+    They move independently and for unrelated reasons: `ours` went 86 → 88 for a deliberate
+    `WireGrouping` fix, while `total` fell 1129 → 853 because EF CORE's own count dropped, which is
+    not an improvement of ours and reads like one. The baseline file records every measurement and
+    why it moved; a number copied into prose only records when it was copied.
 - **Complex types work** (A32) — `ComplexTypesTrackingTestBase` is **249 of 251**, and the two
   left are one shape of one feature: a property-bag complex *collection* on an `Added` entity.
   A complex value cannot ride in the value dictionary an entity is built from — `CreateEntry` and

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -2111,3 +2111,26 @@ rather than staying silent about it.
 
       **Gates: `mkdocs build --strict` green; `release.yml` re-parsed** — five steps, in order, no
       symbols step. No `src/`, no `test/`.
+
+- [x] **N20b. A count copied into prose drifted from the file that owns it.** `<this commit>`
+
+      `CLAUDE.md` said **86** IL trim warnings are ours. `eng/trim-baseline.txt` says **88**, and
+      has since J8 raised it deliberately for a `WireGrouping` fix that needs exactly the two
+      reflection shapes this provider is built on. Nothing is broken and nothing was mis-gated —
+      `eng/trim-ratchet.sh` reads the **baseline file**, never the prose — but a reader checking the
+      gate against the note found them disagreeing.
+
+      **The companion sentence now quotes no number at all**, which is the more useful half. It
+      cited `1129` as the total; the total is `853` today, and it fell for a reason that is **not
+      ours** — EF Core's own count dropped with a package update. A reader seeing "276 fewer
+      warnings" could reasonably conclude this repository improved something. It did not.
+
+      So the prose points at `eng/trim-baseline.txt` and names neither figure. **The baseline file
+      records every measurement and why it moved; a number copied into prose records only when it
+      was copied.**
+
+      Worth stating plainly, since the two counts confuse everyone who meets them: **`ours` is the
+      gated one** — `eng/trim-ratchet.sh` fails on `ours > baseline` and on nothing else. `total`
+      is context, and mostly belongs to other people's assemblies.
+
+      **Gates: none.** One Markdown file, and no script reads it.


### PR DESCRIPTION
A two-line documentation fix. **Nothing is broken and nothing was mis-gated** — `eng/trim-ratchet.sh`
reads `eng/trim-baseline.txt`, never the prose.

## What was wrong

`CLAUDE.md` said **86** IL trim warnings are ours. `eng/trim-baseline.txt` says **88**, and has
since J8 raised it deliberately for a `WireGrouping` fix. A reader checking the gate against the
note found them disagreeing.

## The more useful half: the other number is now gone entirely

The companion sentence cited `1129` as the total. The total is **853** today, and it fell because
**EF Core's own** count dropped with a package update. A reader seeing "276 fewer warnings" could
reasonably conclude this repository improved something. It did not.

So the prose now points at `eng/trim-baseline.txt` and names **neither** figure. That file records
every measurement *and why it moved*; a number copied into prose records only when it was copied.

## For anyone who has never made sense of these counts

| | Meaning | Gated? |
|---|---|---|
| `ours` = 88 | `IL2xxx` warnings whose declaring member is an `InfoCarrier.Core` type | **Yes** — `trim-ratchet.sh` fails on `ours > baseline` and on nothing else |
| `total` = 853 | every assembly: EF Core, Castle, Fluent UI, BCL… | No — context only |

The warnings exist because the wire carries a type's **name** and the far end resolves it, so the
trimmer cannot prove which types a caller's model will need. They mean *unprovable*, not *broken* —
the sample publishes trimmed and runs. They cannot be driven to zero, so the gate is on
**direction**: fail if the number rises.

## Gates

None. One Markdown file, and no script reads it.