### PR TITLE
Record one runner flake beside the flakiness rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -665,6 +665,15 @@ was expected to print.
 already ran it, and repeating that is minutes of wall clock buying nothing. Flakiness is not the
 default assumption.
 
+**One sighting on record, 2026-08-18, and it was the runner rather than this repository.** A
+`Build & Test` run on `main` reported `Total: 11308` against a baseline of `22658` — the host
+crashed mid-`NorthwindJoinQuerySqlite` with `Test host process crashed` and no exception. **The
+ratchet caught it on the total, which is exactly what that guard is for**: failures had "fallen"
+9 → 3, and read alone that is the best result of the day. Re-running the same job on the same
+commit gave `22658 / 22472 / 9 / 177`, and that commit changed only `release.yml` and Markdown, so
+nothing test-affecting differed between the two runs. Not chased further. **If it recurs, that is
+the second sighting and the rule below applies.**
+
 **If you do notice flakiness, it becomes the top priority — before whatever you were doing.** The
 signal is a run that differs from the previous snapshot with **no code change between them**;
 that is the only thing that justifies suspecting it. Stop, find the cause, fix it, and only then

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -2111,3 +2111,26 @@ rather than staying silent about it.
 
       **Gates: `mkdocs build --strict` green; `release.yml` re-parsed** — five steps, in order, no
       symbols step. No `src/`, no `test/`.
+
+- [x] **N20c. One flake sighting, written down so a second one has something to be second to.**
+      `<this commit>`
+
+      A `Build & Test` run on `main` reported `Total: 11308` against a baseline of `22658`:
+      `Test host process crashed`, no exception, mid-`NorthwindJoinQuerySqlite`, after 2m21s where
+      the suite normally takes six and a half minutes.
+
+      **The ratchet caught it on the total, and that is the whole point of that guard.** Failures
+      had "fallen" 9 → 3. Read on its own that is the best result of the day, and the run would have
+      been believed. The total is what says *fewer tests ran*, not *more passed*.
+
+      **Diagnosis: the runner, not this repository.** Re-running the same job on the same commit
+      gave `22658 / 22472 / 9 / 177` in 7m6s. The commit changed only `release.yml` and Markdown —
+      nothing any test touches — and the same suite had completed twice that hour, locally and in
+      CI.
+
+      Not chased further, deliberately: one crash with a clean re-run on identical input is a
+      runner event, and CLAUDE.md's rule already says what to do if it repeats. **What was missing
+      was the record.** The rule says a second sighting is the signal to stop everything; that only
+      works if the first one was written down.
+
+      **Gates: none.** One Markdown file.


### PR DESCRIPTION
A `Build & Test` run on `main` reported:

```
Passed: 11263, Failed: 3, Total: 11308      ← baseline is 22658
The active test run was aborted. Reason: Test host process crashed
```

No exception, mid-`NorthwindJoinQuerySqlite`, after 2m21s where the suite normally takes six and a
half minutes.

## The ratchet caught it on the *total*, which is what that guard is for

Failures had **"fallen" 9 → 3**. Read on its own that is the best result of the day, and the run
would have been believed. The total is what says *fewer tests ran*, not *more passed*.

```
##[error] Total dropped 22658 -> 11308. Tests stopped running rather than started passing.
##[notice] Failures fell 9 -> 3.
```

## Diagnosis: the runner, not this repository

Re-running **the same job on the same commit** gave `22658 / 22472 / 9 / 177` in 7m6s. That commit
changed only `release.yml` and Markdown — nothing any test touches — and the same suite had
completed twice that hour, locally and in CI.

## Why record it rather than investigate it

One crash with a clean re-run on identical input is a runner event. CLAUDE.md's existing rule
already says what to do if it repeats — a second sighting stops everything until it is understood.

**That rule only works if the first sighting was written down.** This is the record, nothing more.

## Gates

None. One Markdown file.