### PR TITLE
Steps N21-N22: how to actually get off 3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,8 @@ samples/Northwind.Client/Properties/launchSettings.json
 
 # The MkDocs output directory. Built by .github/workflows/docs.yml, never committed.
 website/site/
+
+# The virtualenv website/mkdocs.yml tells you to create at the repository root in order to run
+# `mkdocs build --strict` locally. CI installs into the runner instead, so this exists only on a
+# developer machine -- and it is ~50 MB of somebody else's code.
+.venv/

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -2134,3 +2134,43 @@ rather than staying silent about it.
       is context, and mostly belongs to other people's assemblies.
 
       **Gates: none.** One Markdown file, and no script reads it.
+
+- [x] **N21. The upgrade a 3.1 user has to make, written down.** `<this commit>`
+
+      Every user-facing document said the release is not backward compatible with `3.1.1` and none
+      of them said what to *do* about it. `website/docs/getting-started/upgrading-from-3-1.md` is
+      the missing page: what carries over (the `DbContext`, the entities, the queries), the five
+      things that move, and a checklist.
+
+      **Every "before" in it was read out of `subrepos/infocarrier-v1`, not remembered.** The
+      claims that needed checking, and what the source said:
+
+      | Claim | Where it was verified |
+      |---|---|
+      | `UseInfoCarrierClient` → `UseInfoCarrier` | `Client/Extensions/InfoCarrierDbContextOptionsExtensions.cs` |
+      | Sync **and** async pairs, plus `ServerUrl` | `Client/IInfoCarrierClient.cs`, eleven members |
+      | `IInfoCarrierServer` took a `Func<DbContext>` | `Server/IInfoCarrierServer.cs`, four members |
+      | `AddInfoCarrierServer()` existed and is gone | `Server/InfoCarrierServiceCollectionExtensions.cs` |
+      | `TryMapToDynamicObject` → `TryMapToWire` | v1 `Common/ValueMapping/IInfoCarrierValueMapper.cs` against `src/InfoCarrier.Core/ValueMapping/IInfoCarrierValueMapper.cs` |
+      | v1 shipped **no** transport | `grep -rn HttpClient subrepos/infocarrier-v1/src` returns **nothing**; every sample writes its own |
+      | Nine async operations both sides | `src` `IInfoCarrierClient` / `IInfoCarrierServer`, counted |
+
+      **The fact most likely to stop an upgrade dead is the one no other document mentioned**, and
+      it came out of the `.csproj` rather than the API: `3.1.1` is `netstandard2.0`, so it ran on
+      .NET Framework. This generation is `net10.0` only. For a WPF-on-Framework client the upgrade
+      is a port of the client first, and that belongs above the API tables, not in a footnote.
+
+      The `Remote.Linq` line is likewise from the v1 `.csproj`, so "drop any direct reference"
+      names a package that really was there.
+
+      Linked from `index.md` and `installation.md` beside the version warning — the two places a
+      3.1 user actually lands.
+
+      `.gitignore` gains `.venv/`. `website/mkdocs.yml` instructs a reader to create exactly that
+      directory at the repository root and nothing was ignoring it.
+
+      **Gates: `mkdocs build --strict` green — and the gate was shown able to fail on this very
+      file first.** One link in the new page was pointed at `../limitations-typo.md`, the build
+      exited **1** naming the page and the target, and the file was restored from a copy. A strict
+      build that has only ever been seen passing is not evidence that the page's **eight** internal
+      links resolve. No `src/`, no `test/`.

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -2174,3 +2174,21 @@ rather than staying silent about it.
       exited **1** naming the page and the target, and the file was restored from a copy. A strict
       build that has only ever been seen passing is not evidence that the page's **eight** internal
       links resolve. No `src/`, no `test/`.
+
+- [x] **N22. The NuGet readme says what "not backward compatible" costs.** `<this commit>`
+
+      `docs/nuget-readme.md` is the one document a reader meets *before* deciding to install, and
+      it discussed the `3.1.1` trap purely as a version-pinning accident — as though naming the
+      version were the whole problem. It is not: naming the version correctly is what gets you a
+      package your existing code will not compile against.
+
+      Two additions. A short callout under the opening paragraphs, because a 3.1 user has to see it
+      before the code sample rather than after. And an *Upgrading from 3.1* section after
+      *Installing*, holding a **seven-row** before/after table — wiring, transport, endpoint, the
+      three interfaces, dependencies — and ending in a link to N21's page. It is not the same
+      table: N21 spends a section on each of those rows, which is the point of having both.
+
+      nuget.org renders a restricted subset of Markdown, so this is a blockquote and a table and
+      nothing else — no admonitions, which is why the site page and this one do not share text.
+
+      **Gates: none.** One Markdown file, and no script reads it.

--- a/docs/nuget-readme.md
+++ b/docs/nuget-readme.md
@@ -11,6 +11,12 @@ database.
 The `DbContext` and the entity classes are shared source between client and server. You write the
 model once.
 
+> ### ⚠️ Not backward compatible with `3.1.1`
+>
+> This is a ground-up rewrite, not an upgrade. Your `DbContext` and your entity classes carry
+> over unchanged; the wiring around them does not, and existing code will **not** compile.
+> That is deliberate — see [Upgrading from 3.1](#upgrading-from-31) below.
+
 ## Example
 
 ```csharp
@@ -66,6 +72,26 @@ a stable `10.x` ships. Passing `--prerelease` works too.
 to — but pin it anyway, so the two halves cannot drift apart.
 
 Both packages ship symbols and SourceLink, so you can step into the provider from a debugger.
+
+## Upgrading from 3.1
+
+**Your `DbContext` and your entity classes are unchanged.** Everything around them moves.
+
+| | `3.1.1` | `10.0.0-preview.1` |
+|---|---|---|
+| Client wiring | `UseInfoCarrierClient(client)` | `UseInfoCarrier(client)` |
+| Transport | none shipped — yours to write | `HttpInfoCarrierTransport`, or yours |
+| Server endpoint | none shipped — yours to write | `app.MapInfoCarrier()` |
+| `IInfoCarrierClient` | sync **and** async pairs | async only, different shape |
+| `IInfoCarrierServer` | `QueryData` / `SaveChanges` (+ async) | different shape |
+| `IInfoCarrierValueMapper` | `TryMapToDynamicObject` / `TryMapFromDynamicObject` | `TryMapToWire` / `TryMapFromWire` |
+| Dependencies | **Remote.Linq** and Aqua | none beyond `Microsoft.EntityFrameworkCore` |
+
+The three interfaces **kept their names and changed their shapes**, so an existing implementation
+fails to compile rather than compiling and misbehaving.
+
+Step-by-step, with before-and-after code:
+<https://azabluda.github.io/InfoCarrier.Core/getting-started/upgrading-from-3-1/>
 
 ## Status — preview
 

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -73,6 +73,9 @@ the same code, which is what makes the wire format meaningful — see
     The same applies to Central Package Management: pin `10.0.0-preview.1` in
     `Directory.Packages.props`.
 
+    If you are moving an application off `3.1.1`, read
+    [Upgrading from 3.1](upgrading-from-3-1.md) — the model carries over, the wiring does not.
+
 Both packages ship symbol packages and SourceLink, so you can step into the provider from a
 debugger with no extra configuration.
 

--- a/website/docs/getting-started/upgrading-from-3-1.md
+++ b/website/docs/getting-started/upgrading-from-3-1.md
@@ -1,0 +1,184 @@
+# Upgrading from 3.1
+
+InfoCarrier.Core `10.0.0-preview.1` is a ground-up rewrite. It shares its name and its idea with
+the `1.0`–`3.1` line and almost nothing else: the expression serializer, the wire format, the
+client/server split and the security model are all new code.
+
+**Your `DbContext` and your entity classes are unchanged.** Everything around them moves, and it
+will not compile until you have moved it. That is deliberate — the three public interfaces kept
+their names and changed their shapes, so an old implementation fails to build rather than building
+and misbehaving.
+
+!!! warning "Two things to check before you start"
+
+    **The client must run on .NET 10.** `3.1.1` targeted `netstandard2.0`, so it ran on .NET
+    Framework. This generation targets `net10.0` only. If your client is a .NET Framework
+    application, this upgrade is a port of the client first.
+
+    **Name the version when you install.** `3.1.1` is still the newest *stable* release on
+    nuget.org, so an unversioned `dotnet add package` keeps giving you the old line — see
+    [Installation](installation.md#installing).
+
+## What did not change
+
+- The `DbContext` class, its `DbSet<>` properties and its `OnModelCreating`.
+- Your entity classes, and the fact that they are shared source between client and server.
+- The queries you write against them, and `SaveChanges` as a unit of work.
+- The idea: the client has no database, the server has the real one.
+
+## The five things that did
+
+### 1. One package became two
+
+```xml
+<!-- before -->
+<PackageReference Include="InfoCarrier.Core" Version="3.1.1" />
+
+<!-- after — the client and the shared model project -->
+<PackageReference Include="InfoCarrier.Core" Version="10.0.0-preview.1" />
+
+<!-- after — the ASP.NET Core server, in addition to the above -->
+<PackageReference Include="InfoCarrier.Core.AspNetCore" Version="10.0.0-preview.1" />
+```
+
+`Remote.Linq` and `Aqua` are gone; the only remaining dependency is
+`Microsoft.EntityFrameworkCore`. If you referenced either package *directly* — for example to
+configure a serializer — remove it. See [Installation](installation.md) for why the split is
+where it is.
+
+### 2. `UseInfoCarrierClient` became `UseInfoCarrier`
+
+```csharp
+// before
+using InfoCarrier.Core.Client;
+
+optionsBuilder.UseInfoCarrierClient(new MyInfoCarrierClientImpl());
+```
+
+```csharp
+// after
+using InfoCarrier.Core;
+
+optionsBuilder.UseInfoCarrier(client);
+```
+
+### 3. The transport you wrote is now optional
+
+This is the largest saving, and the largest diff. `3.1` shipped **no** transport: every
+application implemented `IInfoCarrierClient` itself, and the samples that came with it ran to
+about a hundred lines each — an `HttpClient`, hand-configured Newtonsoft settings, one route per
+operation, and a cache keyed on a transaction-id header to carry transactions between calls.
+
+All of that is now three objects:
+
+```csharp
+using InfoCarrier.Core;
+
+var serializer = new SystemTextJsonInfoCarrierSerializer();
+using var http = new HttpClient { BaseAddress = new Uri("https://your-app-server") };
+
+IInfoCarrierClient client = new TransportInfoCarrierClient(
+    new HttpInfoCarrierTransport(http, serializer),
+    serializer);
+```
+
+Delete your old client implementation. If you are not on HTTP — WCF, ServiceStack, a message bus,
+a direct in-process call — you now implement `IInfoCarrierTransport`, which is **one method** that
+moves an envelope and interprets nothing, rather than the whole client interface. See
+[Custom transports](../configuration/transports.md).
+
+### 4. The server endpoint ships too
+
+```csharp
+// before: a controller with a route per operation, plus AddInfoCarrierServer()
+[Route("api")]
+public class InfoCarrierController : ControllerBase
+{
+    [HttpPost, Route("QueryData")]
+    public Task<QueryDataResult> PostQueryDataAsync([FromBody] QueryDataRequest request)
+        => this.infoCarrierServer.QueryDataAsync(this.CreateDbContext, request);
+
+    // ... and one action apiece for SaveChanges and the three transaction commands
+}
+```
+
+```csharp
+// after
+using InfoCarrier.Core;
+using InfoCarrier.Core.AspNetCore;
+
+builder.Services.AddDbContext<ShopContext>(o => o.UseSqlServer(connectionString));
+builder.Services.AddScoped<DbContext>(sp => sp.GetRequiredService<ShopContext>());
+
+builder.Services
+    .AddSingleton<IInfoCarrierSerializer, SystemTextJsonInfoCarrierSerializer>()
+    .AddSingleton<IInfoCarrierServer, InProcessInfoCarrierServer>()
+    .AddInfoCarrierStandardValueMappers();
+
+app.MapInfoCarrier();
+```
+
+`AddInfoCarrierServer()` is gone — register `InProcessInfoCarrierServer` yourself, as above.
+`AddScoped<DbContext>` is the line people miss: the server resolves your context by its base type.
+Full detail in [Configuring the server](../configuration/server.md).
+
+### 5. The three interfaces changed shape
+
+Implement these only if you are doing something unusual; most applications now use the shipped
+implementations and touch none of them.
+
+| Interface | `3.1.1` | `10.0.0-preview.1` |
+|---|---|---|
+| `IInfoCarrierClient` | `ServerUrl`, plus sync **and** async pairs of `QueryData`, `SaveChanges` and the three transaction commands | nine `…Async` methods, no sync half, savepoints included |
+| `IInfoCarrierServer` | `QueryData` / `SaveChanges` (+ async), each taking a `Func<DbContext>` | the same nine `…Async` operations as the client; the `DbContext` comes from your service provider |
+| `IInfoCarrierValueMapper` | `TryMapToDynamicObject` / `TryMapFromDynamicObject`, over Aqua's `DynamicObject` | `TryMapToWire(object, Type, out object?)` / `TryMapFromWire(object?, Type, out object?)` |
+
+Two consequences worth calling out:
+
+- **The client contract is async-only.** `3.1`'s sync members existed to satisfy EF Core's
+  synchronous API and were routinely implemented with `.Result` or `.Wait()` — the samples carried
+  a comment linking to the deadlock that causes. Synchronous `DbContext` calls still work; they no
+  longer oblige you to write a blocking transport.
+- **Value mappers moved namespace**, to `InfoCarrier.Core.ValueMapping`, and no longer name a
+  serializer type in their signature. Two are now built in — `IPAddress` and `Uri` — so a mapper
+  you wrote for either can simply be deleted. See
+  [Value mappers](../configuration/value-mappers.md).
+
+## Namespaces, at a glance
+
+| `3.1.1` | `10.0.0-preview.1` |
+|---|---|
+| `InfoCarrier.Core.Client` | `InfoCarrier.Core` |
+| `InfoCarrier.Core.Server` | `InfoCarrier.Core` |
+| `InfoCarrier.Core.Common` | `InfoCarrier.Core.Common` — the wire contracts, unchanged in role |
+| `InfoCarrier.Core.Common.ValueMapping` | `InfoCarrier.Core.ValueMapping` |
+| — | `InfoCarrier.Core.AspNetCore` |
+
+## What you get that 3.1 could not do
+
+Most of this is EF Core 10 rather than InfoCarrier, which is rather the point — the provider
+inherits what the version underneath it can express.
+
+- Complex types, and JSON-mapped owned collections
+- `ExecuteUpdate` and `ExecuteDelete`
+- Many-to-many without an explicit join entity
+- Savepoints — `3.1` had begin, commit and rollback only
+- Spatial types without data loss: Z and M ordinates survive the round trip
+- Blazor WebAssembly, published trimmed — with
+  [one constraint worth reading first](../platforms/blazor-webassembly.md)
+- A stated, tested [security boundary](../security.md) on the server, which `3.1` did not have
+
+## A checklist
+
+1. Confirm the client can target `net10.0`.
+2. Pin `10.0.0-preview.1` on both packages.
+3. Drop any direct `Remote.Linq` or `Aqua` reference.
+4. `UseInfoCarrierClient` → `UseInfoCarrier`, and build the client from the three shipped objects.
+5. Delete your `IInfoCarrierClient` implementation, or reduce it to an `IInfoCarrierTransport`.
+6. Replace the server controller with `MapInfoCarrier()` and the registrations above.
+7. Port any value mapper to `TryMapToWire` / `TryMapFromWire`, deleting `IPAddress` and `Uri` ones.
+8. Read [Limitations](../limitations.md) before you ship.
+
+If something in your application has no route across, please
+[open an issue](https://github.com/azabluda/InfoCarrier.Core/issues) — while this is a preview,
+that feedback still changes the shape of the API.

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -100,6 +100,10 @@ The nine are known, and every one of them is written up on the
     unversioned install resolves to its newest *stable* release — `3.1.1`, built for EF Core 3.1 —
     rather than to this one. See [Installation](getting-started/installation.md).
 
+    **Coming from `3.1`?** This is a rewrite and it is not backward compatible — your model
+    carries over, the wiring around it does not. See
+    [Upgrading from 3.1](getting-started/upgrading-from-3-1.md).
+
     A gRPC binding and streaming results as `IAsyncEnumerable` are still to come, and both may
     change the transport interface.
 

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -110,6 +110,7 @@ nav:
       - Installation: getting-started/installation.md
       - Your first client and server: getting-started/first-app.md
       - Run the samples: getting-started/samples.md
+      - Upgrading from 3.1: getting-started/upgrading-from-3-1.md
   - Using it:
       - Querying: guide/querying.md
       - Saving changes: guide/saving-changes.md


### PR DESCRIPTION
Two commits, both documentation, closing the gap you agreed to in items 2 and 3.

Every user-facing document already says this release is not backward compatible with `3.1.1`.
None of them said what to **do** about it.

### N21 — `website/docs/getting-started/upgrading-from-3-1.md`

What carries over (the `DbContext`, the entities, the queries), the five things that move, and a
checklist. Linked from `index.md` and `installation.md`, beside the version warning — the two
places a 3.1 user actually lands.

**Every "before" in it was read out of `subrepos/infocarrier-v1`, not remembered:**

| Claim | Verified against |
|---|---|
| `UseInfoCarrierClient` → `UseInfoCarrier` | v1 `Client/Extensions/InfoCarrierDbContextOptionsExtensions.cs` |
| Sync **and** async pairs, plus `ServerUrl` | v1 `Client/IInfoCarrierClient.cs` — 11 members |
| `IInfoCarrierServer` took a `Func<DbContext>` | v1 `Server/IInfoCarrierServer.cs` — 4 members |
| `AddInfoCarrierServer()` existed, and is gone | v1 `Server/InfoCarrierServiceCollectionExtensions.cs` |
| `TryMapToDynamicObject` → `TryMapToWire` | both `IInfoCarrierValueMapper.cs` files, side by side |
| v1 shipped **no** transport | `grep -rn HttpClient subrepos/infocarrier-v1/src` returns nothing |
| Nine async operations on each side | `src/` `IInfoCarrierClient` / `IInfoCarrierServer`, counted |

**The fact most likely to stop an upgrade dead is the one no other document mentioned**, and it
came out of the `.csproj` rather than the API: `3.1.1` is `netstandard2.0`, so it ran on .NET
Framework. This generation is `net10.0` only. For a WPF-on-Framework client this is a port of the
client first — so it sits above the API tables, not in a footnote.

`.gitignore` gains `.venv/`: `mkdocs.yml` tells a reader to create exactly that directory at the
repository root and nothing was ignoring it.

### N22 — `docs/nuget-readme.md`

A callout under the opening paragraphs, and an *Upgrading from 3.1* section with a seven-row
before/after table linking to N21's page. Blockquote and table only — nuget.org renders a
restricted subset of Markdown.

**This is the packed README** (`PackagePath="README.md"` in both `.csproj` files), so it reaches
nuget.org on the **next** release. `10.0.0-preview.1` keeps the readme it shipped with.

### Gates

**`mkdocs build --strict` green — and shown able to fail on the new file first.** One link in
`upgrading-from-3-1.md` was pointed at `../limitations-typo.md`; the build exited **1** naming the
page and the target; the file was restored from a copy. A strict build only ever seen passing is
not evidence that the page's eight internal links resolve.

No `src/`, no `test/` — so neither `eng/measure.sh` nor `eng/trim-ratchet.sh` applies, per the
gate table in `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
