### PR TITLE
Steps N24-N25: the site mark finds its place, and a way to preview the site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,10 @@
 # THE GATE IS `--strict`. A link to a page that does not exist, or a page missing from the nav,
 # fails the build. That is the only automated check a documentation site has, so it runs on pull
 # requests too, where nothing is deployed.
+#
+# PREVIEWING A CHANGE. Locally: `eng/docs-serve.sh`, which creates the virtual environment if it is
+# missing and serves the site with live reload. On a pull request: this workflow attaches the built
+# site as the `site-preview` artifact, downloadable from the run page.
 name: Docs
 
 on:
@@ -67,6 +71,24 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           path: website/site
+
+      # A SECOND COPY, FOR HUMANS, ON PULL REQUESTS ONLY. The artifact above is a tarball in the
+      # shape `deploy-pages` wants and is awkward to open by hand; this one is a plain zip of the
+      # site, downloadable from the run page. Unzip it and serve the folder -- `python -m
+      # http.server` inside it -- rather than opening index.html from the filesystem, because the
+      # search index is fetched and a `file://` page is not allowed to fetch it.
+      #
+      # NOT A HOSTED PREVIEW, deliberately. A per-PR URL would mean either moving Pages back to
+      # branch-based publishing (this repository publishes from Actions, and Pages accepts one
+      # source, not both) or adding an external host. Neither is worth it for a site that builds
+      # in twenty seconds.
+      - name: Upload browsable copy (pull requests)
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: site-preview
+          path: website/site
+          retention-days: 14
 
   deploy:
     name: Deploy

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -2387,3 +2387,39 @@ rather than staying silent about it.
       — or an external host. Neither is worth it for a site that builds in twenty seconds.
 
       **Gates: `eng/docs-serve.sh --build` green, and both modes executed.** No `src/`, no `test/`.
+
+- [x] **N24b. N24 is reverted: the header is the theme's again, and the mark moved to the foot of the nav.** `<this commit>`
+
+      **N24 worked and was still the wrong trade.** A 96px mark in a 2.4rem header row does not sit
+      *in* the header — it **becomes** the header, and the sticky chrome went from **96px to
+      156px** on every page before a word of content. That was measured in N24 and recorded as a
+      success; seeing it is what settled it. `theme.logo` is gone, `--md-scroll-margin` is the
+      theme's own `6rem` again because the chrome is stock again (**re-measured: 96px**), and
+      Material's default header logo is back.
+
+      **Three layouts were considered for keeping it big, and the theme's own DOM refused two.**
+      - *Spanning the header and the tabs row* (96px of chrome, exactly what the mark needs):
+        **`.md-tabs` is outside `</header>`**, inside `.md-container`. It is not sticky and scrolls
+        away, so the mark would have been left hanging over the page content.
+      - *Absolutely positioned into the left gutter*: the gutter is `.md-grid`'s centring, which is
+        zero just above the breakpoint where the logo appears at all — Material shows both the logo
+        and the tabs only above **76.25em** — so there is a band of widths where it would land on
+        the title.
+      - *Full-bleed header inner*: works, but moves the search box and the repository block to the
+        far right and pulls the header out of alignment with everything below it.
+
+      **So the mark went where it costs nothing: the foot of the primary sidebar, at 96px.** A
+      `::after` on `.md-sidebar__scrollwrap`, so no template override and no `custom_dir`; the
+      scrollwrap becomes a flex column so `margin-top: auto` pins the mark to the bottom when the
+      navigation is short and simply follows it when it is long. **Both cases rendered** — the home
+      page, whose nav is one item, and `guide/querying/`, whose nav is five — and the navigation is
+      unaffected in both. The sidebar is hidden below the same 76.25em breakpoint, so this is
+      desktop-only for free.
+
+      **What N24 leaves behind is worth keeping even though its change is gone.** The finding that
+      `--md-scroll-margin` is hard-coded and unlinked to the header's height is a real trap for the
+      next person who tries this, and the note in `extra.css` now records why the header route was
+      abandoned rather than leaving it to be rediscovered.
+
+      **Gates: `mkdocs build --strict` green; chrome band re-measured at 96px, matching stock.** No
+      `src/`, no `test/`.

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -2314,3 +2314,41 @@ rather than staying silent about it.
 
       **Gates: `CI=true dotnet build --configuration Release` — 0 errors, the same 5 known
       `IL2110`/`IL2111`. `eng/trim-ratchet.sh` — `OK (88 <= 88)`.** No `src/`, no `test/`.
+
+- [x] **N24. A 96px header mark, and the hidden cost of a taller header.** `<this commit>`
+
+      The site's logo rendered at Material's stock `1.2rem` — 24px — where the badge is the same
+      smudge N23d took out of the sample. It is now **96px**, filling the header line, with the
+      title and the tabs arranging themselves around it.
+
+      **Material is not rigid; one stylesheet is enough.** No `custom_dir`, no template override —
+      `extra_css: [stylesheets/extra.css]` and two selectors. The theme is built out of custom
+      properties and ordinary classes, which is worth recording because the opposite is the natural
+      assumption.
+
+      **The cost is not cosmetic, and nothing fails when you get it wrong.** `--md-scroll-margin`
+      is a **hard-coded `6rem`** in the theme (`3.6rem` without a tabs row) and is **not** computed
+      from the header's height by anything — `md-scroll-margin` appears **zero times** in the
+      theme's JavaScript bundle. A taller header therefore scrolls every `#anchor` target
+      underneath itself, on every deep link in the site, silently. The sticky chrome is
+      `3rem + var(--ic-logo-height)`, and that is not a guess: the indigo band was rendered and
+      counted at three viewport widths and the formula reproduces **156px / 162px / 162px**
+      exactly. The theme leaves `1.2rem` of slack over its own chrome; this keeps it.
+
+      **The mark is sized in `px`, not `rem`, and that came out of measurement too.** Material's
+      root font-size steps up on wide viewports: the stock header-plus-tabs is `4.8rem` and renders
+      **96px up to 1600px and 106px above it**, so one rem is 20px and then 22px. `4.8rem` would
+      have been two different marks on two monitors.
+
+      **Two instruments failed on the way, both silently.**
+      - **Headless Edge renders a blank page for any URL carrying a `#fragment`.** The obvious
+        anchor test — load `…/installation/#installing`, look — returns pure white; the same page
+        without the fragment renders fine. So the anchor claim rests on geometry, not on a picture.
+      - **A correct derivation looked wrong because the arithmetic under it was.** The header
+        growth was computed at 48px against a measured 60px and written off as "the header is not
+        only its logo button". It *is*: the sum was done with `1rem = 16px` when the rendered value
+        is 20px, and at 20px the derivation is exact. **The stock chrome band is the way to read
+        the root font-size, and reading it first would have saved the wrong conclusion.**
+
+      **Gates: `mkdocs build --strict` exit 0, zero warnings; chrome band and clearance measured at
+      1280, 1600 and 1920.** No `src/`, no `test/`.

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -2352,3 +2352,38 @@ rather than staying silent about it.
 
       **Gates: `mkdocs build --strict` exit 0, zero warnings; chrome band and clearance measured at
       1280, 1600 and 1920.** No `src/`, no `test/`.
+
+- [x] **N25. Previewing the site before it is published — locally and on a pull request.** `<this commit>`
+
+      Nothing was wrong here; there was simply no answer to "how do I look at this before it goes
+      live", and the two commands `mkdocs.yml` carried in a comment fail on a fresh clone because
+      the virtual environment they need is git-ignored.
+
+      **`eng/docs-serve.sh`** — live reload, and `--build` for the one-shot `--strict` build CI
+      runs. It creates `.venv` from `website/requirements.txt` when it is missing and is a no-op
+      afterwards.
+
+      **It tries `python3`, `python`, `py` and keeps the first that survives running `-c "pass"`,
+      not the first that resolves.** On this repository's Windows machines `python3` is a Microsoft
+      Store shim: `command -v` finds it and then it refuses to run, which is how
+      `eng/check-project-xml.sh` once reported all ten project files malformed. Demonstrated rather
+      than assumed — the loop prints `skipped: python3`, `picked: python` here, so the `-c "pass"`
+      test is doing work.
+
+      **The script prints no URL, and that is the fix rather than an omission.** Its first version
+      announced `http://127.0.0.1:8000`; the site is served at
+      `http://127.0.0.1:8000/InfoCarrier.Core/`, because `site_url` carries that path — matching
+      where Pages puts it. The root **302**s there, so a browser is fine and a `curl` without `-L`
+      is not, which is exactly how it was found. **mkdocs announces the correct URL itself**, so
+      the line above it could only ever be redundant or wrong.
+
+      **On a pull request, `docs.yml` now attaches the built site as the `site-preview` artifact** —
+      a plain zip, next to the tarball `deploy-pages` wants, 14-day retention, pull requests only.
+      Unzip and *serve* the folder rather than opening `index.html` from disk: the search index is
+      fetched, and a `file://` page is not allowed to fetch it.
+
+      **A hosted per-PR URL was considered and refused.** It needs either moving Pages back to
+      branch-based publishing — Pages takes one source, and this repository publishes from Actions
+      — or an external host. Neither is worth it for a site that builds in twenty seconds.
+
+      **Gates: `eng/docs-serve.sh --build` green, and both modes executed.** No `src/`, no `test/`.

--- a/eng/docs-serve.sh
+++ b/eng/docs-serve.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Preview the documentation site locally, with live reload.
+#
+#     eng/docs-serve.sh            http://127.0.0.1:8000, rebuilds as you save
+#     eng/docs-serve.sh --build    build once into website/site and exit (what CI runs)
+#
+# WHY THIS EXISTS. `mkdocs.yml` has always carried the two commands in a comment, and they are
+# still the whole of it -- but they need a virtual environment that is git-ignored, so the first
+# thing a fresh clone does is fail. This creates it if it is missing and is then a no-op.
+#
+# `--strict` IS NOT OPTIONAL IN THE BUILD MODE. A link to a page that does not exist, or a page
+# missing from the nav, must fail rather than warn: it is the only automated check a documentation
+# site has. `serve` runs without it on purpose, so a half-written link does not stop the preview.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# `python3` resolves to a Microsoft Store shim on this repository's Windows machines and then
+# refuses to run, so a `command -v` test is not enough -- each candidate has to survive executing.
+PY=""
+for c in python3 python py; do
+    if command -v "$c" >/dev/null 2>&1 && "$c" -c "pass" >/dev/null 2>&1; then PY="$c"; break; fi
+done
+[ -n "$PY" ] || { echo "docs-serve: no working python found (tried python3, python, py)" >&2; exit 1; }
+
+# Windows and Linux lay a virtual environment out differently.
+BIN=".venv/bin"
+[ -d ".venv/Scripts" ] && BIN=".venv/Scripts"
+
+if [ ! -x "$BIN/mkdocs" ] && [ ! -x "$BIN/mkdocs.exe" ]; then
+    echo "docs-serve: creating .venv and installing website/requirements.txt…"
+    "$PY" -m venv .venv
+    BIN=".venv/bin"; [ -d ".venv/Scripts" ] && BIN=".venv/Scripts"
+    "$BIN/pip" install --quiet --disable-pip-version-check -r website/requirements.txt
+fi
+
+if [ "${1:-}" = "--build" ]; then
+    exec "$BIN/mkdocs" build --strict --config-file website/mkdocs.yml
+fi
+
+# No URL is printed here on purpose: mkdocs prints its own, and its own is the correct one. The
+# site is served at http://127.0.0.1:8000/InfoCarrier.Core/ rather than at the root, because
+# `site_url` in mkdocs.yml carries that path -- matching where GitHub Pages puts it. Requests to
+# the root 302 there, so a browser is fine either way and a `curl` without `-L` is not.
+exec "$BIN/mkdocs" serve --config-file website/mkdocs.yml "$@"

--- a/website/docs/stylesheets/extra.css
+++ b/website/docs/stylesheets/extra.css
@@ -1,0 +1,52 @@
+/*
+ * Site-specific overrides. Material for MkDocs is themed through CSS custom properties and plain
+ * selectors -- nothing here needs a `custom_dir` or a template override, which is worth saying
+ * because the theme looks far more rigid than it is.
+ *
+ * ONE RULE FOR THIS FILE: every block names the theme rule it is fighting. A stylesheet that
+ * overrides a theme is unreadable a year later otherwise.
+ */
+
+:root {
+    /* The header mark. Material ships `height: 1.2rem`, which renders the badge as a smudge --
+       its lettering lives inside a hexagon and needs room to be legible.
+
+       IN PIXELS RATHER THAN REM, ON PURPOSE. Material's root font-size is not constant: it steps
+       up on wide viewports, and this was measured rather than assumed -- the theme's own header
+       plus tabs is 4.8rem, and rendering it comes out 96px up to 1600px of viewport and 106px
+       above that, so one rem is 20px and then 22px. A logo declared as `4.8rem` is therefore 96px
+       on a laptop and 106px on a desktop monitor. A brand mark should be one size. */
+    --ic-logo-height: 96px;
+}
+
+/* Theme rule: `.md-header__button.md-logo img { height: 1.2rem; width: auto }`.
+   `width: auto` is left alone -- the mark is square, so its height drives everything. */
+.md-header__button.md-logo img,
+.md-header__button.md-logo svg {
+    height: var(--ic-logo-height);
+}
+
+/* Theme rule: `.md-header__button.md-logo { margin: .2rem; padding: .4rem }`. That padding is what
+   sets the header's height around the mark, and .4rem on every side of a 96px image is a lot of
+   indigo. Tightened vertically; the right side is kept so the title does not crowd the mark. */
+.md-header__button.md-logo {
+    margin: 0;
+    padding: 0.3rem 0.5rem 0.3rem 0.2rem;
+}
+
+/* THE PART THAT IS NOT COSMETIC, and the reason a bigger logo is not a one-line change.
+   `--md-scroll-margin` is a HARD-CODED 6rem in the theme (3.6rem without a tabs row). It is NOT
+   computed from the header's height by any script -- the theme's own bundle confirms it, with
+   `md-scroll-margin` appearing zero times in the JavaScript. So a taller header silently scrolls
+   every `#anchor` target underneath itself, on every deep link in the site, with nothing failing.
+
+   The sticky chrome is the tabs row plus the logo button: `2.4rem + (logo + 0.6rem of padding)`,
+   which is `3rem + var(--ic-logo-height)`. That is not a guess -- the indigo band was rendered and
+   counted at three viewport widths, and the formula reproduces all three exactly:
+
+       1280px -> 156px    1600px -> 162px    1920px -> 162px
+
+   The theme leaves 1.2rem of slack over its own chrome (6rem against 4.8rem); this keeps it. */
+:root {
+    --md-scroll-margin: calc(4.2rem + var(--ic-logo-height));
+}

--- a/website/docs/stylesheets/extra.css
+++ b/website/docs/stylesheets/extra.css
@@ -1,52 +1,43 @@
 /*
  * Site-specific overrides. Material for MkDocs is themed through CSS custom properties and plain
- * selectors -- nothing here needs a `custom_dir` or a template override, which is worth saying
- * because the theme looks far more rigid than it is.
+ * selectors -- nothing here needs a `custom_dir` or a template override.
  *
  * ONE RULE FOR THIS FILE: every block names the theme rule it is fighting. A stylesheet that
  * overrides a theme is unreadable a year later otherwise.
  */
 
-:root {
-    /* The header mark. Material ships `height: 1.2rem`, which renders the badge as a smudge --
-       its lettering lives inside a hexagon and needs room to be legible.
-
-       IN PIXELS RATHER THAN REM, ON PURPOSE. Material's root font-size is not constant: it steps
-       up on wide viewports, and this was measured rather than assumed -- the theme's own header
-       plus tabs is 4.8rem, and rendering it comes out 96px up to 1600px of viewport and 106px
-       above that, so one rem is 20px and then 22px. A logo declared as `4.8rem` is therefore 96px
-       on a laptop and 106px on a desktop monitor. A brand mark should be one size. */
-    --ic-logo-height: 96px;
+/*
+ * THE MARK, AT THE FOOT OF THE NAVIGATION -- NOT IN THE HEADER, AND THAT WAS SETTLED BY TRYING IT.
+ *
+ * `theme.logo` puts the mark in the header, where Material sizes it at 1.2rem (24px). At that size
+ * the badge is a smudge: its lettering lives inside a hexagon and there is no room for it. Making
+ * it 96px works, but the header is a 2.4rem row and the mark then *sets* the header's height --
+ * 156px of sticky indigo before any content, on every page. Both were rendered and measured; the
+ * second cost more than the first was worth, so `theme.logo` is gone and the header is the
+ * theme's own again.
+ *
+ * Here the mark has 96px to itself, costs no chrome at all, and sits where the sample application
+ * puts its wordmark. The sidebar is hidden below Material's 76.25em breakpoint, so this is
+ * automatically desktop-only.
+ *
+ * A pseudo-element rather than an <img>, because that needs no template override. The URL is
+ * relative to THIS FILE, hence `../assets/`.
+ */
+/* The scrollwrap is a plain block in the theme; making it a flex column is what lets the mark be
+   pushed to the bottom with `margin-top: auto` when the navigation is short, and simply follow the
+   navigation when it is long. Nothing else in it depends on block layout at this breakpoint. */
+.md-sidebar--primary .md-sidebar__scrollwrap {
+    display: flex;
+    flex-direction: column;
 }
 
-/* Theme rule: `.md-header__button.md-logo img { height: 1.2rem; width: auto }`.
-   `width: auto` is left alone -- the mark is square, so its height drives everything. */
-.md-header__button.md-logo img,
-.md-header__button.md-logo svg {
-    height: var(--ic-logo-height);
-}
-
-/* Theme rule: `.md-header__button.md-logo { margin: .2rem; padding: .4rem }`. That padding is what
-   sets the header's height around the mark, and .4rem on every side of a 96px image is a lot of
-   indigo. Tightened vertically; the right side is kept so the title does not crowd the mark. */
-.md-header__button.md-logo {
-    margin: 0;
-    padding: 0.3rem 0.5rem 0.3rem 0.2rem;
-}
-
-/* THE PART THAT IS NOT COSMETIC, and the reason a bigger logo is not a one-line change.
-   `--md-scroll-margin` is a HARD-CODED 6rem in the theme (3.6rem without a tabs row). It is NOT
-   computed from the header's height by any script -- the theme's own bundle confirms it, with
-   `md-scroll-margin` appearing zero times in the JavaScript. So a taller header silently scrolls
-   every `#anchor` target underneath itself, on every deep link in the site, with nothing failing.
-
-   The sticky chrome is the tabs row plus the logo button: `2.4rem + (logo + 0.6rem of padding)`,
-   which is `3rem + var(--ic-logo-height)`. That is not a guess -- the indigo band was rendered and
-   counted at three viewport widths, and the formula reproduces all three exactly:
-
-       1280px -> 156px    1600px -> 162px    1920px -> 162px
-
-   The theme leaves 1.2rem of slack over its own chrome (6rem against 4.8rem); this keeps it. */
-:root {
-    --md-scroll-margin: calc(4.2rem + var(--ic-logo-height));
+.md-sidebar--primary .md-sidebar__scrollwrap::after {
+    content: "";
+    display: block;
+    flex: none;
+    height: 96px;
+    margin: 1.6rem 0 0.8rem 0.6rem;
+    margin-top: auto;
+    background: url("../assets/logo.png") left center / 96px 96px no-repeat;
+    opacity: 0.85;
 }

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -107,6 +107,11 @@ markdown_extensions:
   - pymdownx.tasklist:
       custom_checkbox: true
 
+# One stylesheet, and it carries its own reasoning. Material is themed through CSS custom
+# properties, so nothing here needs a `custom_dir` or a template override.
+extra_css:
+  - stylesheets/extra.css
+
 plugins:
   - search
 

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -4,7 +4,13 @@
 # a test tier; `docs/` is where those live and it is deliberately not this site's source. Two
 # audiences, two sets of files, and mixing them is what makes internal documents read as promises.
 #
-# Build it locally the way CI does:
+# Preview it locally, with live reload:
+#     eng/docs-serve.sh
+#
+# Build it once, the way CI does:
+#     eng/docs-serve.sh --build
+#
+# Both create `.venv` from website/requirements.txt if it is missing. The long form still works:
 #     python -m venv .venv && .venv/Scripts/pip install -r website/requirements.txt
 #     .venv/Scripts/mkdocs build --strict --config-file website/mkdocs.yml
 #

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -40,11 +40,14 @@ theme:
   # a typeface. Setting this to `false` makes the built site self-contained: the only things it
   # loads are its own bundle and, on a page with a diagram, the Mermaid that ships inside it.
   font: false
-  # The mark shipped on both NuGet packages, so the tab, the header and the package listing are
-  # one identity. Both files are generated from `docs/assets/icon-source.png` by `eng/make-icon.py`
-  # -- MkDocs cannot reach outside `docs_dir`, so the site needs its own copy either way, and
-  # generating it beats copying a 128px PNG that then drifts.
-  logo: assets/logo.png
+  # NO `logo:` ON PURPOSE -- it was tried and removed. Material sizes a header logo at 1.2rem,
+  # where this badge is an illegible smudge, and sizing it up makes the mark set the header's
+  # height: 156px of sticky indigo on every page, measured. The mark is at the foot of the
+  # navigation instead, in `stylesheets/extra.css`, where it has 96px and costs no chrome.
+  #
+  # `assets/logo.png` and `assets/favicon.ico` are generated from `docs/assets/icon-source.png` by
+  # `eng/make-icon.py` -- MkDocs cannot reach outside `docs_dir`, so the site needs its own copy
+  # either way, and generating it beats copying a file that then drifts.
   favicon: assets/favicon.ico
   icon:
     repo: fontawesome/brands/github


### PR DESCRIPTION
Two things: where the mark belongs on the documentation site, and an answer to "how do I preview this before it merges".

Read as three commits, because the middle one undoes the first and the reasoning is the useful part. **The net effect on the header is nothing** — it ends exactly as it started.

## N24 → N24b — the mark ends up at the foot of the navigation

**N24 put the mark in the header at 96px. It worked, and it was the wrong trade.** A 96px mark in a 2.4rem header row does not sit *in* the header, it **becomes** the header: sticky chrome went from **96px to 156px** on every page, before a word of content. Measured, recorded as a success, and obviously wrong once seen.

**N24b reverts it.** `theme.logo` is gone, Material's own header logo is back, and the chrome re-measures at **96px** — stock. The `--md-scroll-margin` override is deleted with it, because the theme's `6rem` is correct again; leaving it would have pushed every anchor 84px too far.

**The mark is now at the foot of the primary sidebar, at 96px** — an `::after` on `.md-sidebar__scrollwrap`, so no `custom_dir` and no template override. The scrollwrap becomes a flex column so `margin-top: auto` pins the mark to the bottom when the nav is short and lets it follow when the nav is long. Both rendered: the home page (nav of one item) and `guide/querying/` (nav of five), nav unaffected in each. The sidebar is hidden below Material's 76.25em breakpoint, so this is desktop-only for free.

### Why the header cannot hold a big mark, from the theme's own DOM

Three layouts were considered; two are not available.

- **Spanning the header and the tabs row** — the 96px of chrome the mark actually needs. **`.md-tabs` is outside `</header>`**, inside `.md-container`. It is not sticky and scrolls away, so the mark would be left hanging over the page content.
- **Absolutely positioned into the left gutter** — the gutter is `.md-grid`'s centring, and it is zero just above **76.25em**, which is the same breakpoint where Material starts showing the logo at all. There is a band of widths where the mark would land on the title.
- **Full-bleed header inner** — works, but throws the search box and the repository block to the far right and pulls the header out of alignment with everything below it.

### The one durable finding, which outlives the change

**`--md-scroll-margin` is a hard-coded `6rem` in the theme** (`3.6rem` without a tabs row) and is **not** derived from the header's height by anything — `md-scroll-margin` appears **zero times** in the theme's JavaScript bundle. Make the header taller and every `#anchor` in the site scrolls its target underneath it, silently. `extra.css` now records this, so the next attempt starts with the warning instead of rediscovering it.

Two supporting measurements, kept because they are cheap to get wrong:

- The sticky chrome is `3rem + logo height`, verified by counting the rendered indigo band at 1280 / 1600 / 1920 (156 / 162 / 162px).
- **Material's root font-size is not constant** — the stock header-plus-tabs of `4.8rem` renders 96px up to 1600px and 106px above it, so one rem is 20px and then 22px. Any header size expressed in rem is two different sizes on two monitors.

### Two instruments failed silently along the way

- **Headless Edge renders a blank page for any URL carrying a `#fragment`.** The obvious anchor test returns pure white; the same page without the fragment renders fine. Anchor claims here rest on geometry, not on a picture.
- **A correct derivation looked 12px short because the arithmetic under it was wrong** — the sum used `1rem = 16px` when the rendered value is 20px. Measuring the stock chrome band is how to read the real root font-size, and doing it first would have prevented the wrong conclusion.

## N25 — previewing the site

**Locally:** `eng/docs-serve.sh` (live reload) or `eng/docs-serve.sh --build` (the one-shot `--strict` build CI runs). Either creates `.venv` from `website/requirements.txt` if it is missing.

It tries `python3`, `python`, `py` and keeps the first that survives running `-c "pass"` — not the first that *resolves*. On Windows `python3` is a Store shim that `command -v` finds and that then refuses to run.

The script prints no URL on purpose. Its first version announced `http://127.0.0.1:8000`; the site is served at `http://127.0.0.1:8000/InfoCarrier.Core/`, because `site_url` carries that path. The root 302s there, so a browser is fine and a `curl` without `-L` is not — which is how it was found. MkDocs announces the correct URL itself.

**On a pull request:** `docs.yml` now attaches the built site as the **`site-preview`** artifact — a plain zip, downloadable from the run page, 14-day retention. Unzip and *serve* the folder (`python -m http.server`) rather than opening `index.html` from disk; the search index is fetched, and a `file://` page may not fetch it.

A hosted per-PR URL was considered and refused: it needs either moving Pages back to branch-based publishing (Pages takes one source, and this repository publishes from Actions) or an external host. Neither is worth it for a site that builds in twenty seconds.

## Gates

`mkdocs build --strict` exit 0, zero warnings; chrome band re-measured at **96px**, matching stock; both script modes executed. **No `src/`, no `test/`.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
