### PR TITLE
Steps N27-N28: the site and the package readmes, and the correction to N27

### DIFF
--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -2519,3 +2519,42 @@ rather than staying silent about it.
       the line.
 
       **Gates: `mkdocs build --strict`, exit 0, zero warnings.** No `src/`, no `test/`.
+
+- [x] **N28. N27 was cosmetic, and `docs/nuget-readme.md` was the proof.** `<this commit>`
+
+      N27 claimed to give every user-facing document *"the same treatment"* as N26. It applied
+      **two of the skill's thirty-five sections** by string substitution, and left the structural
+      principles N26 established untouched.
+
+      | N26 principle | applied in N27 |
+      |---|---|
+      | Docs link in the first ten lines | no |
+      | No test counts | two files of twenty-one |
+      | No security essay, link instead | no |
+      | One example, not four | no |
+      | Cut content rather than reword it | **no** |
+
+      **`docs/nuget-readme.md` is the clearest failure.** It kept a *Two packages* table, a *Status*
+      section, a *Security* section and a full upgrade table, every one of which the README had
+      dropped, so the two documents described the same product with opposite structures. It is now
+      the same shape: the same four sections in the same order, the same three snippets under
+      *Getting started*, **131 lines each**. The extra words are the two callouts that only matter
+      on nuget.org. Every link is absolute, because nuget.org cannot resolve a relative path.
+
+      **A phrase removed from the README for being this exact pattern survived in
+      `samples/README.md`** — *"sharing the type makes that true by construction rather than by
+      discipline"*. That is what a mechanical pass looks like from the outside: the tell is fixed
+      where you looked and untouched everywhere else.
+
+      **What stays, and why it is not the same thing.** *"in the model rather than in the CLR
+      type"*, *"refused rather than resolved"*, *"a class rather than a dictionary"*, *"wrong
+      answers rather than errors"*. A contrast between two concrete outcomes **is** the information,
+      and the skill's own false-positive list says to keep real alternatives. The pattern worth
+      removing is the rhetorical one, where the second half carries nothing.
+
+      **The lesson, and it is the one N26 already recorded in a weaker form.** Invoking the skill is
+      not applying it. §14 and §15 are countable, so they are the ones a hurried pass does; §9, §27,
+      §28 and §32 need the sentence read, so they are the ones it skips. **A metric that goes to
+      zero is evidence about the metric.**
+
+      **Gates: `mkdocs build --strict`, exit 0, zero warnings.** No `src/`, no `test/`.

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -2558,3 +2558,33 @@ rather than staying silent about it.
       zero is evidence about the metric.**
 
       **Gates: `mkdocs build --strict`, exit 0, zero warnings.** No `src/`, no `test/`.
+
+- [x] **N29. `samples/README.md`, through the skill properly.** `<this commit>`
+
+      The first document in the planned one-at-a-time pass, and the file the earlier sweep had
+      damaged least and improved least. **Length and content are kept deliberately**: this file is
+      the samples' own notes, its reader is someone working on the repository, so the fix is the
+      prose rather than the scope.
+
+      Read whole, patterns marked, then **rewritten rather than patched**. Bold spans in prose fall
+      **27 → 3**, and the three that stay are the page names *Customers*, *Order* and *Transfer*,
+      which are labels on a screen.
+
+      **Three sayings removed, each doing rhetoric where a sentence would do.** *"This is the point
+      of the sample, and it is four lines."* *"…are gone, and that is the plan working"*, which
+      announced its own significance instead of saying what happened. *"The round-trip counts are
+      the interesting part"*, which told the reader to be interested rather than what to look at.
+
+      **And the internal milestone id.** *"in M8-22 they were"* named something no reader of this
+      file can resolve, and the sentence works without it.
+
+      **What stays, on purpose:** *"the server's answer rather than the local change tracker
+      agreeing with itself"*, *"from row indices rather than from `Random`"*, *"wrong answers rather
+      than errors"*. Each contrasts two concrete outcomes, which is the information rather than the
+      pattern.
+
+      **Sixteen figures verified present after the rewrite** (the five seed counts, Fluent UI
+      4.14.4, EF issue 31751, port 5199, 17 transport tests, the five trim counts, 330 order lines,
+      14 round trips), and every code block and the console transcript are byte-identical.
+
+      **Gates: none.** Not part of the site build; no `src/`, no `test/`.

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -2479,3 +2479,43 @@ rather than staying silent about it.
       **Gates: none.** No `src/`, no `test/`, and neither file is part of the site build. Every
       relative link in both files was resolved against the working tree, and every site URL against
       `mkdocs.yml`.
+
+- [x] **N27. The same treatment for every other user-facing document.** `<this commit>`
+
+      N26 settled the principles on the README. This applies them to the other twenty-one
+      user-facing documents: `docs/nuget-readme.md`, `samples/README.md`, `docs/limitations.md`,
+      and all seventeen pages under `website/docs/`.
+
+      **Measured before and after, outside fenced code blocks**, because a comment inside a sample
+      is the sample's text and not this repository's prose:
+
+      | | before | after |
+      |---|---|---|
+      | em dashes in prose | 190 | **0** |
+      | bold-label bullet lists | 20 | **0** |
+
+      **Four pages were rewritten rather than edited**, because their problems were structural.
+      `docs/nuget-readme.md` dropped the raw suite numbers and the emoji callout, and *Installing*
+      moved above *Two packages* so a reader meets the `3.1.1` version trap before the packaging
+      discussion. `website/docs/index.md` lost four bold-label bullets and its verbatim test-count
+      block. `website/docs/security.md` lost twelve bold spans and a four-item bold list that was
+      padding four real warnings. `website/docs/configuration/server.md` opened five consecutive
+      paragraphs with a bold API name and a dash.
+
+      **Everything else was edited line by line.** Only sentences carrying a tell were touched, so
+      the rest of each file is byte-identical and the diff is reviewable rather than a wall of
+      re-flowed text. 21 files, 273 insertions, 282 deletions.
+
+      **Two judgement calls, both from the skill's own false-positive list.** The
+      `**Affects you if**` / `**What happens**` / `**Workaround**` / `**Cause**` labels in both
+      limitations documents are field labels in a reference document, which the skill says not to
+      flag; only the dashes after them were removed. And the em dash inside sample code comments
+      stays, because the skill leaves code blocks alone.
+
+      **The mechanical route is the wrong one here, and the reason is worth keeping.** A regex over
+      `—` produces grammatical rubbish: the right replacement is a comma, a colon, a semicolon, a
+      full stop or a rewritten clause depending on what the sentence is doing, and roughly a third
+      of these needed the clause rewritten. Every replacement in this step was chosen by reading
+      the line.
+
+      **Gates: `mkdocs build --strict`, exit 0, zero warnings.** No `src/`, no `test/`.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,6 +1,6 @@
 # Known limitations
 
-InfoCarrier.Core runs Microsoft's own Entity Framework Core specification test suite — the same
+InfoCarrier.Core runs Microsoft's own Entity Framework Core specification test suite, the same
 suite EF Core's SQL Server, SQLite and InMemory providers run. This page lists **every scenario in
 that suite that does not behave the way a normal EF Core provider behaves**, so you can judge
 whether any of them affects your application.
@@ -14,7 +14,7 @@ suite and it passes.
 
 ### Inserting an entity whose complex property is a property bag
 
-**Affects you if** you map a complex property — or a complex collection — whose CLR type is
+**Affects you if** you map a complex property, or a complex collection, whose CLR type is
 `Dictionary<string, object>`. EF Core calls this a *property bag*: the shape is declared in the
 model rather than in the CLR type.
 
@@ -36,7 +36,7 @@ modelBuilder.Entity<Product>()
     });
 ```
 
-**What happens** — the insert throws:
+**What happens.** The insert throws:
 
 ```csharp
 context.Products.Add(new Product
@@ -55,7 +55,7 @@ The same applies to the collection form, `List<Dictionary<string, object>>` mapp
 covered by EF's suite for this shape**, so treat the whole write path as unsupported rather than
 assuming update works.
 
-**Workaround** — declare the complex type as an ordinary class:
+**Workaround.** Declare the complex type as an ordinary class:
 
 ```csharp
 public class ProductSpec
@@ -77,7 +77,7 @@ modelBuilder.Entity<Product>().ComplexProperty(e => e.Spec);
 Every other complex-type shape is supported, including nested complex types and complex
 collections, as long as the type is a class rather than a dictionary.
 
-**Cause** — a defect in EF Core's own materializer, reached because this provider rebuilds entities
+**Cause.** A defect in EF Core's own materializer, reached because this provider rebuilds entities
 on the server from the values sent over the wire. Tracked upstream as
 [dotnet/efcore#36175](https://github.com/dotnet/efcore/issues/36175).
 
@@ -104,11 +104,11 @@ var report = context.Customers
     .ToList();
 ```
 
-**What happens** — the query runs and returns a result. **No EF Core provider supports this
+**What happens.** The query runs and returns a result. No EF Core provider supports this
 query**: SQL Server, SQLite and InMemory all reject it. Because no provider executes it, there is
 no reference answer to check ours against, so the result this provider returns is unverified.
 
-**Workaround** — apply `Distinct` after materialising:
+**Workaround.** Apply `Distinct` after materialising:
 
 ```csharp
 Products = o.Lines.Select(l => l.ProductName).ToList(),   // then .Distinct() in memory
@@ -124,7 +124,7 @@ provider, and you may notice the difference when porting code or tests.
 ### Exception message text for an untranslatable query
 
 When a query cannot be translated, this provider throws `InvalidOperationException`, exactly as EF
-Core does. **The message text may differ** in two cases — a method call inside an `ExecuteUpdate`
+Core does. **The message text may differ** in two cases: a method call inside an `ExecuteUpdate`
 property selector, and a cast to a type nothing in your model implements:
 
 ```csharp
@@ -138,7 +138,7 @@ IQueryable orders = context.Orders;
 orders.Cast<IArchivable>().FirstOrDefault();
 ```
 
-Both throw. **Catch the exception type; do not match on message text** — that is unsupported on any
+Both throw. **Catch the exception type; do not match on message text.** That is unsupported on any
 EF Core provider.
 
 ### Queries this provider answers that other providers reject

--- a/docs/nuget-readme.md
+++ b/docs/nuget-readme.md
@@ -3,19 +3,17 @@
 **Use the full power of Entity Framework Core in a client application that has no database.**
 
 InfoCarrier.Core is a non-relational EF Core provider that you deploy on the *client* side of a
-multi-tier application. Your client gets a real `DbContext` — LINQ, change tracking, the identity
-map, navigation fix-up, lazy loading, transactions — but no connection string and no database
+multi-tier application. Your client gets a real `DbContext` with LINQ, change tracking, the identity
+map, navigation fix-up, lazy loading and transactions, but no connection string and no database
 driver. Queries and units of work travel to your application server and run there against the real
 database.
 
-The `DbContext` and the entity classes are shared source between client and server. You write the
+The `DbContext` and the entity classes are shared source between client and server, so you write the
 model once.
 
-> ### ⚠️ Not backward compatible with `3.1.1`
->
-> This is a ground-up rewrite, not an upgrade. Your `DbContext` and your entity classes carry
-> over unchanged; the wiring around them does not, and existing code will **not** compile.
-> That is deliberate — see [Upgrading from 3.1](#upgrading-from-31) below.
+> **Not backward compatible with `3.1.1`.** This is a ground-up rewrite. Your `DbContext` and your
+> entity classes carry over unchanged; the wiring around them does not, and existing code will not
+> compile. See [Upgrading from 3.1](#upgrading-from-31) below.
 
 ## Example
 
@@ -38,23 +36,8 @@ recent[0].Freight = 0m;
 await context.SaveChangesAsync();   // a unit of work, executed on the server
 ```
 
-That query is not evaluated on the client. It crosses the wire as an expression tree and the server
-runs it against SQL Server, SQLite, PostgreSQL — whatever your server-side provider is.
-
-## Two packages
-
-| Package | What it is for | Cost |
-|---|---|---|
-| **`InfoCarrier.Core`** | The provider, the wire contracts, and `HttpInfoCarrierTransport` | one dependency: `Microsoft.EntityFrameworkCore` |
-| **`InfoCarrier.Core.AspNetCore`** | `app.MapInfoCarrier()` — the server endpoint | a framework reference to `Microsoft.AspNetCore.App` |
-
-**A client references only `InfoCarrier.Core`.** The HTTP transport is in it because it costs
-nothing — `System.Net.Http` is in the shared framework, so it is safe in Blazor WebAssembly. The
-ASP.NET Core endpoint is a separate package precisely because it is *not* free: a WPF, MAUI or
-WebAssembly client must not have to be an ASP.NET Core app to restore its data-access library.
-
-`IInfoCarrierTransport` is one method, so HTTP is a default rather than a requirement. gRPC, WCF,
-a message bus or a direct in-process call are all a small class.
+That query is not evaluated on the client. It crosses the wire as an expression tree, and the server
+runs it against SQL Server, SQLite, PostgreSQL, or whatever provider the server uses.
 
 ## Installing
 
@@ -63,74 +46,81 @@ dotnet add package InfoCarrier.Core --version 10.0.0-preview.1              # th
 dotnet add package InfoCarrier.Core.AspNetCore --version 10.0.0-preview.1   # the server endpoint
 ```
 
-**Name the version.** `InfoCarrier.Core` has been on nuget.org since **1.0**, and its newest
-*stable* release is **`3.1.1`** — the earlier line, built for EF Core 3.1. An unversioned
-`dotnet add package InfoCarrier.Core` installs that one, not this one, and will keep doing so until
-a stable `10.x` ships. Passing `--prerelease` works too.
+> **Name the version.** `InfoCarrier.Core` has been on nuget.org since 1.0, and its newest *stable*
+> release is `3.1.1`, the earlier line built for EF Core 3.1. An unversioned
+> `dotnet add package InfoCarrier.Core` installs that one, and will keep doing so until a stable
+> `10.x` ships. Passing `--prerelease` works too.
 
-`InfoCarrier.Core.AspNetCore` is new in this generation, so it has no older version to fall back
-to — but pin it anyway, so the two halves cannot drift apart.
+`InfoCarrier.Core.AspNetCore` is new in this generation and has no older version to fall back to,
+but pin it anyway so the two halves cannot drift apart.
 
 Both packages ship symbols and SourceLink, so you can step into the provider from a debugger.
 
+## Two packages
+
+| Package | What it is for | Cost |
+|---|---|---|
+| `InfoCarrier.Core` | The provider, the wire contracts, and `HttpInfoCarrierTransport` | one dependency: `Microsoft.EntityFrameworkCore` |
+| `InfoCarrier.Core.AspNetCore` | `app.MapInfoCarrier()`, the server endpoint | a framework reference to `Microsoft.AspNetCore.App` |
+
+A client references only `InfoCarrier.Core`. The HTTP transport is in it because it costs nothing:
+`System.Net.Http` is in the shared framework, so it is safe in Blazor WebAssembly. The ASP.NET Core
+endpoint is a separate package because it is not free, and a WPF, MAUI or WebAssembly client should
+not have to be an ASP.NET Core app to restore its data-access library.
+
+To use gRPC, WCF or a message bus instead of HTTP, you implement one small interface.
+
 ## Upgrading from 3.1
 
-**Your `DbContext` and your entity classes are unchanged.** Everything around them moves.
+Your `DbContext` and your entity classes are unchanged. Everything around them moves.
 
 | | `3.1.1` | `10.0.0-preview.1` |
 |---|---|---|
 | Client wiring | `UseInfoCarrierClient(client)` | `UseInfoCarrier(client)` |
-| Transport | none shipped — yours to write | `HttpInfoCarrierTransport`, or yours |
-| Server endpoint | none shipped — yours to write | `app.MapInfoCarrier()` |
-| `IInfoCarrierClient` | sync **and** async pairs | async only, different shape |
+| Transport | none shipped, yours to write | `HttpInfoCarrierTransport`, or yours |
+| Server endpoint | none shipped, yours to write | `app.MapInfoCarrier()` |
+| `IInfoCarrierClient` | sync and async pairs | async only, different shape |
 | `IInfoCarrierServer` | `QueryData` / `SaveChanges` (+ async) | different shape |
 | `IInfoCarrierValueMapper` | `TryMapToDynamicObject` / `TryMapFromDynamicObject` | `TryMapToWire` / `TryMapFromWire` |
-| Dependencies | **Remote.Linq** and Aqua | none beyond `Microsoft.EntityFrameworkCore` |
+| Dependencies | Remote.Linq and Aqua | none beyond `Microsoft.EntityFrameworkCore` |
 
-The three interfaces **kept their names and changed their shapes**, so an existing implementation
-fails to compile rather than compiling and misbehaving.
+The three interfaces kept their names and changed their shapes, so an existing implementation fails
+to compile instead of compiling and misbehaving.
 
-Step-by-step, with before-and-after code:
+Step by step, with before-and-after code:
 <https://azabluda.github.io/InfoCarrier.Core/getting-started/upgrading-from-3-1/>
 
-## Status — preview
+## Status
 
 This package is `10.0.0-preview.1`. It is exercised by Microsoft's own
 `EFCore.Specification.Tests`, the same suite EF Core's SQL Server, SQLite and InMemory providers
-run:
+run. The failures that remain are known, classified, and gated in CI so their number cannot grow
+unnoticed.
 
-```
-Total tests: 22658, Passed: 22472, Failed: 9, Skipped: 177
-```
-
-The nine failures are known, classified, and gated in CI so the number cannot grow unnoticed. They
-amount to one unsupported scenario, one query to treat with caution, and a few differences that are
-not defects.
-
-**Read the limitations page before adopting:**
+Read the limitations page before adopting:
 <https://azabluda.github.io/InfoCarrier.Core/limitations/>
 
-Still to come before a stable release: a shipped gRPC binding and streaming results as
+Still to come before a stable release: a shipped gRPC binding, and streaming results as
 `IAsyncEnumerable`.
 
 ## Security
 
-The server executes an expression tree that arrived over the network. That is bounded deliberately
-— a default-deny allowlist over node kinds, types and methods, no assembly loaded to satisfy a
-payload, and reflection entry points blocked. The review, its adversarial tests, and the weaknesses
-that are *accepted rather than solved*, are at
+Your server executes an expression tree that arrived over the network. That path is bounded by a
+default-deny allowlist over node kinds, types and methods; no assembly is loaded to satisfy a
+payload; and the reflection entry points that would turn a resolved `Type` into a call are blocked.
+The review, its adversarial tests, and the weaknesses that are accepted rather than solved, are at
 <https://github.com/azabluda/InfoCarrier.Core/blob/main/docs/security-review.md>.
 
-**Authentication and authorization are out of scope and are yours.** No identity travels in the
+Authentication and authorization are out of scope and remain yours. No identity travels in the
 envelope. Authenticate the transport, and use query filters on the server's model to decide what a
 caller may see.
 
 ## Documentation and samples
 
-**Documentation:** <https://azabluda.github.io/InfoCarrier.Core/>
+Documentation: <https://azabluda.github.io/InfoCarrier.Core/>
 
-**Source and samples:** <https://github.com/azabluda/InfoCarrier.Core>
+Source and samples: <https://github.com/azabluda/InfoCarrier.Core>
 
 ## License
 
-MIT — Copyright (c) Alexander Zabluda.
+MIT, Copyright (c) Alexander Zabluda.

--- a/docs/nuget-readme.md
+++ b/docs/nuget-readme.md
@@ -2,27 +2,86 @@
 
 **Use the full power of Entity Framework Core in a client application that has no database.**
 
-InfoCarrier.Core is a non-relational EF Core provider that you deploy on the *client* side of a
-multi-tier application. Your client gets a real `DbContext` with LINQ, change tracking, the identity
-map, navigation fix-up, lazy loading and transactions, but no connection string and no database
-driver. Queries and units of work travel to your application server and run there against the real
-database.
+[Documentation](https://azabluda.github.io/InfoCarrier.Core/) &nbsp;·&nbsp;
+[Limitations](https://azabluda.github.io/InfoCarrier.Core/limitations/) &nbsp;·&nbsp;
+[Source](https://github.com/azabluda/InfoCarrier.Core)
 
-The `DbContext` and the entity classes are shared source between client and server, so you write the
-model once.
+InfoCarrier.Core is a non-relational provider for Entity Framework Core that you deploy on the
+*client* side of a multi-tier application. Your client gets a real `DbContext` with LINQ, change
+tracking, the identity map, navigation fix-up, lazy loading and transactions, but no connection
+string and no database driver. Queries and units of work travel to your application server and run
+there against the real database.
 
-> **Not backward compatible with `3.1.1`.** This is a ground-up rewrite. Your `DbContext` and your
-> entity classes carry over unchanged; the wiring around them does not, and existing code will not
-> compile. See [Upgrading from 3.1](#upgrading-from-31) below.
+> **Coming from 3.1?** This is a rewrite, not an upgrade. Your `DbContext` and your entity classes
+> carry over unchanged; the wiring around them does not, and existing code will not compile. See
+> [Upgrading from 3.1](https://azabluda.github.io/InfoCarrier.Core/getting-started/upgrading-from-3-1/).
 
-## Example
+## What works
+
+- Queries, including the client/server projection split
+- `SaveChanges`, including many-to-many graphs
+- Lazy loading, and transactions with savepoints
+- Complex types, JSON-mapped owned collections, spatial types, compiled models
+- Blazor WebAssembly, published trimmed
+- HTTP out of the box. To use gRPC, WCF or a message bus instead, you implement one small
+  interface
+
+## What does not
+
+The [limitations page](https://azabluda.github.io/InfoCarrier.Core/limitations/) lists every
+scenario that behaves differently from a normal EF Core provider, with a worked example for each.
+It is a short read, and worth doing before you adopt.
+
+## Getting started
+
+```bash
+# client and server
+dotnet add package InfoCarrier.Core --version 10.0.0-preview.1
+
+# server endpoint
+dotnet add package InfoCarrier.Core.AspNetCore --version 10.0.0-preview.1
+```
+
+> **Name the version.** `InfoCarrier.Core` has been on nuget.org since 1.0, and its newest *stable*
+> release is `3.1.1`, built for EF Core 3.1. An unversioned `dotnet add package InfoCarrier.Core`
+> installs that one, and will keep doing so until a stable `10.x` ships. `--prerelease` works too.
+
+### The shared model
 
 ```csharp
-// In a WPF, Blazor WebAssembly, MAUI or console app — no database here.
+// A project referenced by both the client and the server.
+public class NorthwindContext(DbContextOptions<NorthwindContext> options) : DbContext(options)
+{
+    public DbSet<Customer> Customers => Set<Customer>();
+    public DbSet<Order> Orders => Set<Order>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+        => modelBuilder.Entity<Order>()
+            .HasOne(e => e.Customer)
+            .WithMany()
+            .HasForeignKey(e => e.CustomerId);
+}
+```
+
+The client and the server must build the same model, so the context and the entity classes live in
+a project that both of them reference.
+
+### The client
+
+```csharp
+// A WPF, Blazor WebAssembly, MAUI or console app. There is no database in this process.
+var serializer = new SystemTextJsonInfoCarrierSerializer();
+using var httpClient = new HttpClient { BaseAddress = new Uri("https://your-app-server") };
+
+IInfoCarrierClient client = new TransportInfoCarrierClient(
+    new HttpInfoCarrierTransport(httpClient, serializer),
+    serializer);
+
 var options = new DbContextOptionsBuilder<NorthwindContext>()
     .UseInfoCarrier(client)
     .Options;
 
+// Everything below this line is ordinary EF Core.
 await using var context = new NorthwindContext(options);
 
 var recent = await context.Orders
@@ -36,91 +95,37 @@ recent[0].Freight = 0m;
 await context.SaveChangesAsync();   // a unit of work, executed on the server
 ```
 
-That query is not evaluated on the client. It crosses the wire as an expression tree, and the server
-runs it against SQL Server, SQLite, PostgreSQL, or whatever provider the server uses.
+That query is not evaluated on the client. It crosses the wire as an expression tree, and the
+server runs it against SQL Server, SQLite, PostgreSQL, or whatever provider the server uses.
 
-## Installing
+### The server
 
-```bash
-dotnet add package InfoCarrier.Core --version 10.0.0-preview.1              # the client and the server
-dotnet add package InfoCarrier.Core.AspNetCore --version 10.0.0-preview.1   # the server endpoint
+```csharp
+builder.Services.AddDbContext<NorthwindContext>(o => o.UseSqlServer(connectionString));
+builder.Services.AddScoped<DbContext>(sp => sp.GetRequiredService<NorthwindContext>());
+
+builder.Services
+    .AddSingleton<IInfoCarrierSerializer, SystemTextJsonInfoCarrierSerializer>()
+    .AddSingleton<IInfoCarrierServer, InProcessInfoCarrierServer>()
+    .AddInfoCarrierStandardValueMappers();
+
+// One endpoint, from InfoCarrier.Core.AspNetCore.
+app.MapInfoCarrier();
 ```
 
-> **Name the version.** `InfoCarrier.Core` has been on nuget.org since 1.0, and its newest *stable*
-> release is `3.1.1`, the earlier line built for EF Core 3.1. An unversioned
-> `dotnet add package InfoCarrier.Core` installs that one, and will keep doing so until a stable
-> `10.x` ships. Passing `--prerelease` works too.
+Your server executes an expression tree that arrived over the network. Read the
+[security page](https://azabluda.github.io/InfoCarrier.Core/security/) before you expose the
+endpoint.
 
-`InfoCarrier.Core.AspNetCore` is new in this generation and has no older version to fall back to,
-but pin it anyway so the two halves cannot drift apart.
+## Credits
 
-Both packages ship symbols and SourceLink, so you can step into the provider from a debugger.
+Built on [Entity Framework Core](https://github.com/dotnet/efcore) and judged by its test suite.
 
-## Two packages
-
-| Package | What it is for | Cost |
-|---|---|---|
-| `InfoCarrier.Core` | The provider, the wire contracts, and `HttpInfoCarrierTransport` | one dependency: `Microsoft.EntityFrameworkCore` |
-| `InfoCarrier.Core.AspNetCore` | `app.MapInfoCarrier()`, the server endpoint | a framework reference to `Microsoft.AspNetCore.App` |
-
-A client references only `InfoCarrier.Core`. The HTTP transport is in it because it costs nothing:
-`System.Net.Http` is in the shared framework, so it is safe in Blazor WebAssembly. The ASP.NET Core
-endpoint is a separate package because it is not free, and a WPF, MAUI or WebAssembly client should
-not have to be an ASP.NET Core app to restore its data-access library.
-
-To use gRPC, WCF or a message bus instead of HTTP, you implement one small interface.
-
-## Upgrading from 3.1
-
-Your `DbContext` and your entity classes are unchanged. Everything around them moves.
-
-| | `3.1.1` | `10.0.0-preview.1` |
-|---|---|---|
-| Client wiring | `UseInfoCarrierClient(client)` | `UseInfoCarrier(client)` |
-| Transport | none shipped, yours to write | `HttpInfoCarrierTransport`, or yours |
-| Server endpoint | none shipped, yours to write | `app.MapInfoCarrier()` |
-| `IInfoCarrierClient` | sync and async pairs | async only, different shape |
-| `IInfoCarrierServer` | `QueryData` / `SaveChanges` (+ async) | different shape |
-| `IInfoCarrierValueMapper` | `TryMapToDynamicObject` / `TryMapFromDynamicObject` | `TryMapToWire` / `TryMapFromWire` |
-| Dependencies | Remote.Linq and Aqua | none beyond `Microsoft.EntityFrameworkCore` |
-
-The three interfaces kept their names and changed their shapes, so an existing implementation fails
-to compile instead of compiling and misbehaving.
-
-Step by step, with before-and-after code:
-<https://azabluda.github.io/InfoCarrier.Core/getting-started/upgrading-from-3-1/>
-
-## Status
-
-This package is `10.0.0-preview.1`. It is exercised by Microsoft's own
-`EFCore.Specification.Tests`, the same suite EF Core's SQL Server, SQLite and InMemory providers
-run. The failures that remain are known, classified, and gated in CI so their number cannot grow
-unnoticed.
-
-Read the limitations page before adopting:
-<https://azabluda.github.io/InfoCarrier.Core/limitations/>
-
-Still to come before a stable release: a shipped gRPC binding, and streaming results as
-`IAsyncEnumerable`.
-
-## Security
-
-Your server executes an expression tree that arrived over the network. That path is bounded by a
-default-deny allowlist over node kinds, types and methods; no assembly is loaded to satisfy a
-payload; and the reflection entry points that would turn a resolved `Type` into a call are blocked.
-The review, its adversarial tests, and the weaknesses that are accepted rather than solved, are at
-<https://github.com/azabluda/InfoCarrier.Core/blob/main/docs/security-review.md>.
-
-Authentication and authorization are out of scope and remain yours. No identity travels in the
-envelope. Authenticate the transport, and use query filters on the server's model to decide what a
-caller may see.
-
-## Documentation and samples
-
-Documentation: <https://azabluda.github.io/InfoCarrier.Core/>
-
-Source and samples: <https://github.com/azabluda/InfoCarrier.Core>
-
-## License
+[InfoCarrier.Core 1.0 to 3.1](https://github.com/azabluda/InfoCarrier.Core/tree/master), by
+[on/off it-solutions gmbh](http://www.onoff-it-solutions.info), proved the idea. It was inspired by
+[Remote.Linq](https://github.com/6bee/Remote.Linq) and
+[aqua-core](https://github.com/6bee/aqua-core) by Christof Senn, and built on them: they carried the
+expression serialization in every version up to 3.1. Version 10 has its own serializer and no longer
+depends on them.
 
 MIT, Copyright (c) Alexander Zabluda.

--- a/samples/README.md
+++ b/samples/README.md
@@ -24,7 +24,7 @@ Three pages, and a **wire inspector** down the right-hand side showing every rou
 operation, the size each way, how long it took, and the decoded payload, including the
 expression tree, which the panel expands out of the base64 it travels in.
 
-**Customers** is an ordinary grid, and that is the point of it. Click a header to sort, open a
+**Customers** is deliberately an ordinary grid. Click a header to sort, open a
 column's filter to narrow it, page through the rest. There is no *Run* button, because there is
 nothing to run: sorting and filtering are already part of the expression tree the page sends.
 Sorting is composed on the `IQueryable<Customer>` **before** `Skip`/`Take`, never through the
@@ -104,8 +104,8 @@ configuration from the **startup application's own service provider**, silently 
 client's `IDesignTimeDbContextFactory`. The generated model was the *server's*: annotated
 `Relational:TableName` and `Proxies:LazyLoading = true`. The browser was running on a relational,
 proxied model and appeared to work, which is the dangerous shape, because model divergence between
-the two halves produces wrong answers rather than errors. It is removed rather than made almost
-right.
+the two halves produces wrong answers rather than errors. The compiled model is removed; a nearly
+correct one would have been worse than none.
 
 ## Run it in a console
 
@@ -183,7 +183,7 @@ than the numbers being wrong.
 
 | Project | What it is |
 |---|---|
-| `Northwind.Shared` | The model and **one** `NorthwindContext`, used by both halves. The wire carries entity type *names*, so the two models must agree; sharing the type makes that true by construction rather than by discipline. |
+| `Northwind.Shared` | The model and **one** `NorthwindContext`, used by both halves. The wire carries entity type *names*, so the two models must agree, and sharing the type is what guarantees it. |
 | `Northwind.Server` | ASP.NET Core + SQLite. `app.MapInfoCarrier()` is the one route it owns; everything else is the browser client's, which this host also serves, so there is one origin and no CORS. Creates and seeds `northwind.db` at start-up. |
 | `Northwind.Client` | The Blazor WebAssembly client: three pages, the wire inspector, and no database. |
 | `Northwind.Demo` | The console client above. |

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,13 +1,13 @@
 # Samples
 
-A client whose `DbContext` has **no database**, talking to a SQLite-backed server over HTTP.
+A client whose `DbContext` has no database, talking to a SQLite-backed server over HTTP.
 
-> Using the library rather than working on it? The documentation site is the place to start:
+> Using the library rather than working on it? Start at the documentation site:
 > <https://azabluda.github.io/InfoCarrier.Core/>. This file is the samples' own notes: what each
 > page demonstrates, and what running them established.
 
-There are two clients, and they are the same client twice: a **browser** (Blazor WebAssembly) and
-a **console**. Both build the same `NorthwindContext` from `Northwind.Shared`, both wire it with
+There are two clients, and they are the same client twice: one a browser (Blazor WebAssembly), one
+a console. Both build the same `NorthwindContext` from `Northwind.Shared`, both wire it with
 `UseInfoCarrier`, and neither has a connection string.
 
 ## Run it in a browser
@@ -20,59 +20,59 @@ dotnet run --project samples/Northwind.Server
 
 Then open <http://localhost:5199>.
 
-Three pages, and a **wire inspector** down the right-hand side showing every round trip: the
-operation, the size each way, how long it took, and the decoded payload, including the
-expression tree, which the panel expands out of the base64 it travels in.
+Three pages, and a wire inspector down the right-hand side showing every round trip: the operation,
+the size each way, how long it took, and the decoded payload, including the expression tree, which
+the panel expands out of the base64 it travels in.
 
-**Customers** is deliberately an ordinary grid. Click a header to sort, open a
-column's filter to narrow it, page through the rest. There is no *Run* button, because there is
-nothing to run: sorting and filtering are already part of the expression tree the page sends.
-Sorting is composed on the `IQueryable<Customer>` **before** `Skip`/`Take`, never through the
-grid's own `ApplySorting`, which would sort the client-side projection record and quietly leave you
-with server-side paging over client-side sorting. Filtering `Country` for *Germany* takes 65 rows to
-8 and the panel shows the `Where` crossing the wire.
+**Customers** is deliberately an ordinary grid. Click a header to sort, open a column's filter to
+narrow it, page through the rest. There is no *Run* button, because there is nothing to run: sorting
+and filtering are already part of the expression tree the page sends. Sorting is composed on the
+`IQueryable<Customer>` before `Skip`/`Take`, never through the grid's own `ApplySorting`, which
+would sort the client-side projection record and quietly leave you with server-side paging over
+client-side sorting. Filtering `Country` for *Germany* takes 65 rows to 8, and the panel shows the
+`Where` crossing the wire.
 
-Each active filter shows as a chip in the grid footer that clears it. That is this sample's own
-control rather than the grid's: `ColumnBase.Filtered` renders nothing in Fluent UI 4.14.4, so
-without it an active filter is invisible and the item count is the only clue.
+Each active filter shows as a chip in the grid footer that clears it. That chip is this sample's own
+control rather than the grid's, because `ColumnBase.Filtered` renders nothing in Fluent UI 4.14.4,
+and without it an active filter is invisible with the item count as the only clue.
 
 **Order** is a master-detail screen: a paged, sortable grid of orders on the left, the selected
-order's detail on the right. It runs **two** `DbContext`s on purpose. The grid takes a fresh one per
-page, because a grid provider may ask again before the last answer lands and a `DbContext` is not
-thread-safe; the detail keeps one per selected order, because the unit of work is the thing being
-demonstrated: several quantity edits accumulate in one change tracker and leave as one
-`SaveChanges`. The master list is a projection over a join, so it shows *Alfreds Futterkiste* rather
-than `ALFKI` and the server does the joining.
+order's detail on the right. It runs two `DbContext` instances on purpose. The grid takes a fresh
+one per page, because a grid provider may ask again before the last answer lands and a `DbContext`
+is not thread-safe. The detail keeps one per selected order, because the unit of work is the thing
+being demonstrated: several quantity edits accumulate in one change tracker and leave as one
+`SaveChanges`. The master list is a projection over a join, so it shows *Alfreds Futterkiste*
+instead of `ALFKI`, and the server does the joining.
 
 **Transfer** moves order 1 to another customer and takes a unit off a product's stock, both inside
 one transaction, and offers a tickbox that makes the second save fail on the *server's* database.
 You pick the new owner by company name; the id stays the bound value, because that is what the
 foreign key needs. Either way the panel shows the whole shape, from `BeginTransaction` through the
-saves to `Commit` or `Rollback`, and both figures are read back afterwards through a fresh context, so they
-are the server's answer rather than the local change tracker agreeing with itself.
+saves to `Commit` or `Rollback`. Both figures are read back afterwards through a fresh context, so
+they are the server's answer rather than the local change tracker agreeing with itself.
 
-The store is seeded with **65 customers, 240 orders, 476 order lines, 30 products and 8
-categories**, enough that the grid pages properly and each page change is visibly its own query.
-The data is generated from row indices rather than from `Random`, so it is byte-identical on every
-machine: `InfoCarrier.Core.TransportTests` asserts exact counts against it.
+The store is seeded with 65 customers, 240 orders, 476 order lines, 30 products and 8 categories,
+enough that the grid pages properly and each page change is visibly its own query. The data is
+generated from row indices rather than from `Random`, so it is byte-identical on every machine, and
+`InfoCarrier.Core.TransportTests` asserts exact counts against it.
 
 ### Two things WebAssembly will not do
 
-Both were found by running this app. Neither is this provider's constraint. They are the
-browser's, and the console demo below has neither.
+Running this app is how both were found. Neither is this provider's constraint. They belong to the
+browser, and the console demo below has neither.
 
 #### 1. Automatic lazy loading
 
 `order.Customer` throws `PlatformNotSupportedException: Cannot wait on monitors on this runtime`,
-and throws it *after* the request has already gone out, so the inspector shows the round trip
-while the value never arrives.
+and throws it *after* the request has already gone out, so the inspector shows the round trip while
+the value never arrives.
 
-A navigation property getter is **synchronous**, so a lazy load has to *block* on the HTTP round
-trip, and a single-threaded runtime cannot block. `ILazyLoader.Load()` is synchronous too, so
-injecting a loader instead fails identically.
+A navigation property getter is synchronous, so a lazy load has to block on the HTTP round trip, and
+a single-threaded runtime cannot block. `ILazyLoader.Load()` is synchronous too, so injecting a
+loader instead fails identically.
 
-**What the sample does:** the browser client does not enable lazy-loading proxies at all, so an
-unloaded navigation is simply `null` rather than a confusing exception from inside a proxy. The
+The sample sidesteps it. The browser client does not enable lazy-loading proxies at all, so an
+unloaded navigation is simply `null` instead of a confusing exception from inside a proxy, and the
 Order page loads navigations explicitly:
 
 ```csharp
@@ -80,16 +80,16 @@ await context.Entry(order).Reference(o => o.Customer).LoadAsync();
 await context.Entry(order).Collection(o => o.OrderDetails).LoadAsync();
 ```
 
-Nothing about the demonstration is lost: the navigation is still not fetched by the original query,
+Nothing about the demonstration is lost. The navigation is still not fetched by the original query,
 and asking for it still costs exactly one round trip.
 
-The **server** still calls `UseLazyLoadingProxies()`, because it is not a browser. That asymmetry is safe:
-proxies change how an entity is constructed on the side that enables them, and the wire carries
-entity type *names*.
+The server still calls `UseLazyLoadingProxies()`, because it is not a browser. That asymmetry is
+safe: proxies change how an entity is constructed on the side that enables them, and the wire
+carries entity type *names*.
 
 #### 2. A compiled model
 
-`dotnet ef dbcontext optimize` output cannot be loaded in WebAssembly as generated: EF initializes
+`dotnet ef dbcontext optimize` output cannot be loaded in WebAssembly as generated. EF initializes
 the model on a `new Thread(…, 10 MB)` to avoid stack overflow on large models
 ([EF issue 31751](https://github.com/dotnet/efcore/issues/31751)), and WebAssembly has no threads.
 Reading `Instance` throws `TypeInitializationException` wrapping `PlatformNotSupportedException`
@@ -97,15 +97,15 @@ from `Thread.Start`, and the app never renders at all. EF's own escape hatch,
 `AppContext.SetSwitch("Microsoft.EntityFrameworkCore.Issue31751", true)`, makes it initialize
 inline, and that does work.
 
-**The sample no longer uses one anyway, for a second and better reason.** `dotnet ef dbcontext
-optimize` needs a startup project it can load, and a Blazor WebAssembly project emits no
-`deps.json`, so the server has to be the startup project. But EF's tooling then takes the
-configuration from the **startup application's own service provider**, silently ignoring the
-client's `IDesignTimeDbContextFactory`. The generated model was the *server's*: annotated
-`Relational:TableName` and `Proxies:LazyLoading = true`. The browser was running on a relational,
-proxied model and appeared to work, which is the dangerous shape, because model divergence between
-the two halves produces wrong answers rather than errors. The compiled model is removed; a nearly
-correct one would have been worse than none.
+The sample no longer uses one anyway, for a second and better reason. `dotnet ef dbcontext optimize`
+needs a startup project it can load, and a Blazor WebAssembly project emits no `deps.json`, so the
+server has to be the startup project. EF's tooling then takes the configuration from the startup
+application's own service provider, silently ignoring the client's `IDesignTimeDbContextFactory`.
+The generated model was the server's, annotated `Relational:TableName` and
+`Proxies:LazyLoading = true`. The browser was running on a relational, proxied model and appeared to
+work, which is the dangerous shape, because model divergence between the two halves produces wrong
+answers rather than errors. The compiled model is removed; a nearly correct one would have been
+worse than none.
 
 ## Run it in a console
 
@@ -122,9 +122,9 @@ dotnet run --project samples/Northwind.Demo
 The server's launch profile pins `http://localhost:5199`; the demo defaults to the same address and
 takes an override as its first argument.
 
-Expected output **against a freshly seeded store**, which is what the caveat below the transcript
-is about: the browser pages write to the same `northwind.db`, and the Transfer page in particular
-moves order 1 to another customer, so a store that has been clicked through answers differently:
+The output below assumes a freshly seeded store, which is what the caveat after the transcript is
+about: the browser pages write to the same `northwind.db`, and the Transfer page in particular moves
+order 1 to another customer, so a store that has been clicked through answers differently.
 
 ```
   InfoCarrier.Core — Northwind demo
@@ -163,44 +163,44 @@ moves order 1 to another customer, so a store that has been clicked through answ
   Done. 14 round trips, none of which touched a database in this process.
 ```
 
-The round-trip counts are the interesting part. Lazy loading costs a request *when the navigation is
-touched*, and two edits cost **one** save. The projection takes only the first eight orders, and the
-`Take` is part of the expression tree, so the server returns eight rows rather than the client
-trimming a list it already paid to receive.
+Watch the round-trip counts. Lazy loading costs a request when the navigation is touched, and two
+edits cost one save. The projection takes only the first eight orders, and the `Take` is part of the
+expression tree, so the server returns eight rows rather than the client trimming a list it already
+paid to receive.
 
-**The console client lazy-loads normally**, unlike the browser: it is not WebAssembly, so a
+The console client lazy-loads normally, unlike the browser, because it is not WebAssembly and a
 synchronous navigation getter can block on the round trip. That is the same asymmetry described
 above, seen from the other side.
 
-**Delete `northwind.db` beside the server binary if you want these exact numbers.** The transcript
-above is a fresh store: order 1 belongs to `ALFKI` and 330 order lines have a quantity of 10 or
-more, both of which `InfoCarrier.Core.TransportTests` asserts against the same seed. Click through
-the browser pages first and the same run prints `1:BERGS` and a different count, because the Transfer page
-moved the order and the Order page edited quantities, which is the demonstration working rather
-than the numbers being wrong.
+Delete `northwind.db` beside the server binary if you want these exact numbers. The transcript above
+is a fresh store: order 1 belongs to `ALFKI`, and 330 order lines have a quantity of 10 or more,
+both of which `InfoCarrier.Core.TransportTests` asserts against the same seed. Click through the
+browser pages first and the same run prints `1:BERGS` and a different count, because the Transfer
+page moved the order and the Order page edited quantities. That is the demonstration working, not
+the numbers being wrong.
 
 ## The projects
 
 | Project | What it is |
 |---|---|
-| `Northwind.Shared` | The model and **one** `NorthwindContext`, used by both halves. The wire carries entity type *names*, so the two models must agree, and sharing the type is what guarantees it. |
-| `Northwind.Server` | ASP.NET Core + SQLite. `app.MapInfoCarrier()` is the one route it owns; everything else is the browser client's, which this host also serves, so there is one origin and no CORS. Creates and seeds `northwind.db` at start-up. |
+| `Northwind.Shared` | The model and one `NorthwindContext`, used by both halves. The wire carries entity type *names*, so the two models must agree, and sharing the type is what guarantees it. |
+| `Northwind.Server` | ASP.NET Core and SQLite. `app.MapInfoCarrier()` is the one route it owns; everything else is the browser client's, which this host also serves, so there is one origin and no CORS. Creates and seeds `northwind.db` at start-up. |
 | `Northwind.Client` | The Blazor WebAssembly client: three pages, the wire inspector, and no database. |
 | `Northwind.Demo` | The console client above. |
 
-**`Northwind.Client.Transport` and `Northwind.Server/Transport/` are gone, and that is the plan
-working.** Both were written free of Northwind types so they could be promoted into packages, and
-in M8-22 they were, as a file move, exactly as intended. `HttpInfoCarrierTransport` is now in
-**`InfoCarrier.Core`** (it costs nothing: `System.Net.Http` is in the shared framework, which is
-what makes it WebAssembly-safe), and `MapInfoCarrier` is in **`InfoCarrier.Core.AspNetCore`** (a
-framework reference to `Microsoft.AspNetCore.App`, which is why it is not in the client package).
+`Northwind.Client.Transport` and `Northwind.Server/Transport/` are gone, which is what they were
+built for. Both were written free of Northwind types so that they could be promoted into packages,
+and they were, as a file move. `HttpInfoCarrierTransport` is now in `InfoCarrier.Core`, where it
+costs nothing because `System.Net.Http` is in the shared framework, which is what makes it
+WebAssembly-safe. `MapInfoCarrier` is in `InfoCarrier.Core.AspNetCore`, which carries a framework
+reference to `Microsoft.AspNetCore.App`, which is why it is not in the client package.
 
-So the samples now reference the product the way an application would, and there is no
-sample-owned transport left to keep honest.
+So the samples now reference the product the way an application would, and no sample-owned transport
+is left to keep honest.
 
 ## The whole client wiring
 
-This is the point of the sample, and it is four lines:
+Four lines, and this is what the sample exists to show:
 
 ```csharp
 var serializer = new SystemTextJsonInfoCarrierSerializer();
@@ -218,26 +218,26 @@ No connection string, no provider for a store, no database.
 dotnet publish samples/Northwind.Client -c Release
 ```
 
-The client publishes with `PublishTrimmed=true` and runs: all three pages were driven against
-the published output. It reports **88 IL trim warnings owned by `InfoCarrier.Core`**, and that is a
-known, recorded number rather than a clean bill of health: the wire carries a type's *name* and the
-far end resolves it, so `Assembly.GetType(string)` and `MakeGenericMethod` are what this provider is
-made of, and `[DynamicallyAccessedMembers]` cannot describe them. The warnings mean the trimmer
-cannot *prove* the reflection safe for an arbitrary model, not that it broke this one.
+The client publishes with `PublishTrimmed=true` and runs. All three pages were driven against the
+published output. It reports 88 IL trim warnings owned by `InfoCarrier.Core`, and that number is
+recorded and gated rather than zero: the wire carries a type's *name* and the far end resolves it,
+so `Assembly.GetType(string)` and `MakeGenericMethod` are what this provider is made of, and
+`[DynamicallyAccessedMembers]` cannot describe them. The warnings mean the trimmer cannot *prove*
+the reflection safe for an arbitrary model. They do not mean it broke this one.
 
-`eng/trim-ratchet.sh` gates the direction of that count against `eng/trim-baseline.txt`, exactly as
-`eng/ratchet.sh` gates the spec suite. Everyone else's warnings are reported but not gated, since EF Core
-alone contributes 585 of the 853 total.
+`eng/trim-ratchet.sh` gates the direction of that count against `eng/trim-baseline.txt`, the same
+way `eng/ratchet.sh` gates the specification suite. Everyone else's warnings are reported and not
+gated, since EF Core alone contributes 585 of the 853 total.
 
 Both numbers have moved since they were first measured, in opposite directions and for unrelated
-reasons, which is why `eng/trim-baseline.txt` records each one rather than only the current value.
-`ours` rose 86 → 88 deliberately, for a `GroupBy` fix that needs exactly the two reflection shapes
-this provider is built on; `total` fell 1129 → 853 because EF Core's own count dropped, and none of
-that improvement is this repository's.
+reasons, which is why `eng/trim-baseline.txt` records each measurement instead of only the current
+value. `ours` rose 86 to 88 deliberately, for a `GroupBy` fix that needs exactly the two reflection
+shapes this provider is built on. `total` fell 1129 to 853 because EF Core's own count dropped, and
+none of that improvement belongs to this repository.
 
 ## What is not here yet
 
-- No automated test of the pages. The 17 tests in `test/InfoCarrier.Core.TransportTests` cover
-  the protocol over a real HTTP hop; the three pages were verified by driving a real browser, and
-  that harness is not in the repository. CI would not notice a page breaking, only that the
-  client still builds and publishes.
+- No automated test of the pages. The 17 tests in `test/InfoCarrier.Core.TransportTests` cover the
+  protocol over a real HTTP hop; the three pages were verified by driving a real browser, and that
+  harness is not in the repository. CI would not notice a page breaking, only that the client still
+  builds and publishes.

--- a/samples/README.md
+++ b/samples/README.md
@@ -3,7 +3,7 @@
 A client whose `DbContext` has **no database**, talking to a SQLite-backed server over HTTP.
 
 > Using the library rather than working on it? The documentation site is the place to start:
-> <https://azabluda.github.io/InfoCarrier.Core/>. This file is the samples' own notes — what each
+> <https://azabluda.github.io/InfoCarrier.Core/>. This file is the samples' own notes: what each
 > page demonstrates, and what running them established.
 
 There are two clients, and they are the same client twice: a **browser** (Blazor WebAssembly) and
@@ -21,11 +21,11 @@ dotnet run --project samples/Northwind.Server
 Then open <http://localhost:5199>.
 
 Three pages, and a **wire inspector** down the right-hand side showing every round trip: the
-operation, the size each way, how long it took, and the **decoded** payload — including the
+operation, the size each way, how long it took, and the decoded payload, including the
 expression tree, which the panel expands out of the base64 it travels in.
 
 **Customers** is an ordinary grid, and that is the point of it. Click a header to sort, open a
-column's filter to narrow it, page through the rest — there is no *Run* button, because there is
+column's filter to narrow it, page through the rest. There is no *Run* button, because there is
 nothing to run: sorting and filtering are already part of the expression tree the page sends.
 Sorting is composed on the `IQueryable<Customer>` **before** `Skip`/`Take`, never through the
 grid's own `ApplySorting`, which would sort the client-side projection record and quietly leave you
@@ -40,31 +40,31 @@ without it an active filter is invisible and the item count is the only clue.
 order's detail on the right. It runs **two** `DbContext`s on purpose. The grid takes a fresh one per
 page, because a grid provider may ask again before the last answer lands and a `DbContext` is not
 thread-safe; the detail keeps one per selected order, because the unit of work is the thing being
-demonstrated — several quantity edits accumulate in one change tracker and leave as **one**
+demonstrated: several quantity edits accumulate in one change tracker and leave as one
 `SaveChanges`. The master list is a projection over a join, so it shows *Alfreds Futterkiste* rather
 than `ALFKI` and the server does the joining.
 
 **Transfer** moves order 1 to another customer and takes a unit off a product's stock, both inside
 one transaction, and offers a tickbox that makes the second save fail on the *server's* database.
 You pick the new owner by company name; the id stays the bound value, because that is what the
-foreign key needs. Either way the panel shows the whole shape — `BeginTransaction`, the saves, then
-`Commit` or `Rollback` — and both figures are read back afterwards through a fresh context, so they
+foreign key needs. Either way the panel shows the whole shape, from `BeginTransaction` through the
+saves to `Commit` or `Rollback`, and both figures are read back afterwards through a fresh context, so they
 are the server's answer rather than the local change tracker agreeing with itself.
 
 The store is seeded with **65 customers, 240 orders, 476 order lines, 30 products and 8
-categories** — enough that the grid pages properly and each page change is visibly its own query.
+categories**, enough that the grid pages properly and each page change is visibly its own query.
 The data is generated from row indices rather than from `Random`, so it is byte-identical on every
 machine: `InfoCarrier.Core.TransportTests` asserts exact counts against it.
 
 ### Two things WebAssembly will not do
 
-Both were found by running this app. **Neither is this provider's constraint** — they are the
+Both were found by running this app. Neither is this provider's constraint. They are the
 browser's, and the console demo below has neither.
 
 #### 1. Automatic lazy loading
 
 `order.Customer` throws `PlatformNotSupportedException: Cannot wait on monitors on this runtime`,
-and throws it *after* the request has already gone out — so the inspector shows the round trip
+and throws it *after* the request has already gone out, so the inspector shows the round trip
 while the value never arrives.
 
 A navigation property getter is **synchronous**, so a lazy load has to *block* on the HTTP round
@@ -83,7 +83,7 @@ await context.Entry(order).Collection(o => o.OrderDetails).LoadAsync();
 Nothing about the demonstration is lost: the navigation is still not fetched by the original query,
 and asking for it still costs exactly one round trip.
 
-The **server** still calls `UseLazyLoadingProxies()` — it is not a browser. That asymmetry is safe:
+The **server** still calls `UseLazyLoadingProxies()`, because it is not a browser. That asymmetry is safe:
 proxies change how an entity is constructed on the side that enables them, and the wire carries
 entity type *names*.
 
@@ -93,17 +93,17 @@ entity type *names*.
 the model on a `new Thread(…, 10 MB)` to avoid stack overflow on large models
 ([EF issue 31751](https://github.com/dotnet/efcore/issues/31751)), and WebAssembly has no threads.
 Reading `Instance` throws `TypeInitializationException` wrapping `PlatformNotSupportedException`
-from `Thread.Start`, and the app never renders at all. EF's own escape hatch —
-`AppContext.SetSwitch("Microsoft.EntityFrameworkCore.Issue31751", true)` — makes it initialize
+from `Thread.Start`, and the app never renders at all. EF's own escape hatch,
+`AppContext.SetSwitch("Microsoft.EntityFrameworkCore.Issue31751", true)`, makes it initialize
 inline, and that does work.
 
 **The sample no longer uses one anyway, for a second and better reason.** `dotnet ef dbcontext
 optimize` needs a startup project it can load, and a Blazor WebAssembly project emits no
-`deps.json` — so the server has to be the startup project. But EF's tooling then takes the
+`deps.json`, so the server has to be the startup project. But EF's tooling then takes the
 configuration from the **startup application's own service provider**, silently ignoring the
 client's `IDesignTimeDbContextFactory`. The generated model was the *server's*: annotated
 `Relational:TableName` and `Proxies:LazyLoading = true`. The browser was running on a relational,
-proxied model and appeared to work — which is the dangerous shape, because model divergence between
+proxied model and appeared to work, which is the dangerous shape, because model divergence between
 the two halves produces wrong answers rather than errors. It is removed rather than made almost
 right.
 
@@ -123,7 +123,7 @@ The server's launch profile pins `http://localhost:5199`; the demo defaults to t
 takes an override as its first argument.
 
 Expected output **against a freshly seeded store**, which is what the caveat below the transcript
-is about — the browser pages write to the same `northwind.db`, and the Transfer page in particular
+is about: the browser pages write to the same `northwind.db`, and the Transfer page in particular
 moves order 1 to another customer, so a store that has been clicked through answers differently:
 
 ```
@@ -165,7 +165,7 @@ moves order 1 to another customer, so a store that has been clicked through answ
 
 The round-trip counts are the interesting part. Lazy loading costs a request *when the navigation is
 touched*, and two edits cost **one** save. The projection takes only the first eight orders, and the
-`Take` is part of the expression tree — the server returns eight rows rather than the client
+`Take` is part of the expression tree, so the server returns eight rows rather than the client
 trimming a list it already paid to receive.
 
 **The console client lazy-loads normally**, unlike the browser: it is not WebAssembly, so a
@@ -175,7 +175,7 @@ above, seen from the other side.
 **Delete `northwind.db` beside the server binary if you want these exact numbers.** The transcript
 above is a fresh store: order 1 belongs to `ALFKI` and 330 order lines have a quantity of 10 or
 more, both of which `InfoCarrier.Core.TransportTests` asserts against the same seed. Click through
-the browser pages first and the same run prints `1:BERGS` and a different count — the Transfer page
+the browser pages first and the same run prints `1:BERGS` and a different count, because the Transfer page
 moved the order and the Order page edited quantities, which is the demonstration working rather
 than the numbers being wrong.
 
@@ -190,7 +190,7 @@ than the numbers being wrong.
 
 **`Northwind.Client.Transport` and `Northwind.Server/Transport/` are gone, and that is the plan
 working.** Both were written free of Northwind types so they could be promoted into packages, and
-in M8-22 they were — as a file move, exactly as intended. `HttpInfoCarrierTransport` is now in
+in M8-22 they were, as a file move, exactly as intended. `HttpInfoCarrierTransport` is now in
 **`InfoCarrier.Core`** (it costs nothing: `System.Net.Http` is in the shared framework, which is
 what makes it WebAssembly-safe), and `MapInfoCarrier` is in **`InfoCarrier.Core.AspNetCore`** (a
 framework reference to `Microsoft.AspNetCore.App`, which is why it is not in the client package).
@@ -218,7 +218,7 @@ No connection string, no provider for a store, no database.
 dotnet publish samples/Northwind.Client -c Release
 ```
 
-The client publishes with `PublishTrimmed=true` **and runs** — all three pages were driven against
+The client publishes with `PublishTrimmed=true` and runs: all three pages were driven against
 the published output. It reports **88 IL trim warnings owned by `InfoCarrier.Core`**, and that is a
 known, recorded number rather than a clean bill of health: the wire carries a type's *name* and the
 far end resolves it, so `Assembly.GetType(string)` and `MakeGenericMethod` are what this provider is
@@ -226,7 +226,7 @@ made of, and `[DynamicallyAccessedMembers]` cannot describe them. The warnings m
 cannot *prove* the reflection safe for an arbitrary model, not that it broke this one.
 
 `eng/trim-ratchet.sh` gates the direction of that count against `eng/trim-baseline.txt`, exactly as
-`eng/ratchet.sh` gates the spec suite. Everyone else's warnings are reported but not gated — EF Core
+`eng/ratchet.sh` gates the spec suite. Everyone else's warnings are reported but not gated, since EF Core
 alone contributes 585 of the 853 total.
 
 Both numbers have moved since they were first measured, in opposite directions and for unrelated
@@ -237,7 +237,7 @@ that improvement is this repository's.
 
 ## What is not here yet
 
-- **No automated test of the pages.** The 17 tests in `test/InfoCarrier.Core.TransportTests` cover
+- No automated test of the pages. The 17 tests in `test/InfoCarrier.Core.TransportTests` cover
   the protocol over a real HTTP hop; the three pages were verified by driving a real browser, and
-  that harness is not in the repository. CI would not notice a page breaking — only that the
+  that harness is not in the repository. CI would not notice a page breaking, only that the
   client still builds and publishes.

--- a/website/docs/api-surface.md
+++ b/website/docs/api-surface.md
@@ -37,8 +37,8 @@ All types are in `InfoCarrier.Core` unless stated otherwise.
 | `IInfoCarrierTransport` | `SendAsync(InfoCarrierEnvelope, CancellationToken)` | [Custom transports](configuration/transports.md) |
 | `IInfoCarrierSerializer` | `Serialize<T>`, `Deserialize<T>`, and async counterparts | [Custom transports](configuration/transports.md#a-different-serializer) |
 | `InfoCarrier.Core.ValueMapping.IInfoCarrierValueMapper` | `TryMapToWire`, `TryMapFromWire` | [Value mappers](configuration/value-mappers.md) |
-| `IInfoCarrierServer` | The nine server operations | — |
-| `IInfoCarrierClient` | The client half of the same nine | — |
+| `IInfoCarrierServer` | The nine server operations | none |
+| `IInfoCarrierClient` | The client half of the same nine | none |
 
 `IInfoCarrierServer` and `IInfoCarrierClient` exist to be substituted in unusual hosting
 arrangements. Most applications use `InProcessInfoCarrierServer` and `TransportInfoCarrierClient`
@@ -57,7 +57,7 @@ unchanged.
 | `InfoCarrierTransportException` | The request never reached a server, or what came back was not an envelope. |
 | `InfoCarrierServerException` | The server's own exception type cannot be rebuilt here. Carries `ServerExceptionTypeName`. |
 
-Anything else you catch is EF Core's own — `DbUpdateException`, `DbUpdateConcurrencyException`,
+Anything else you catch is EF Core's own: `DbUpdateException`, `DbUpdateConcurrencyException`,
 `InvalidOperationException`. See [Handling errors](guide/errors.md).
 
 ## Wire contracts

--- a/website/docs/configuration/client.md
+++ b/website/docs/configuration/client.md
@@ -7,7 +7,7 @@ you want to change.
 optionsBuilder.UseInfoCarrier(client);
 ```
 
-Everything else on `DbContextOptionsBuilder` is EF Core's and works as usual — logging,
+Everything else on `DbContextOptionsBuilder` is EF Core's and works as usual: logging,
 `EnableSensitiveDataLogging`, `ConfigureWarnings`, query-tracking behaviour, proxies.
 
 ## The three objects
@@ -34,7 +34,7 @@ new HttpInfoCarrierTransport(httpClient, serializer, requestUri: "infocarrier");
 ```
 
 The third argument is the route, relative to the `HttpClient`'s `BaseAddress`. It defaults to
-`"infocarrier"`, which is also what `MapInfoCarrier()` defaults to on the server — change one and
+`"infocarrier"`, which is also what `MapInfoCarrier()` defaults to on the server. Change one and
 change the other.
 
 Everything else about the HTTP call is the `HttpClient`'s: base address, timeout, headers,
@@ -73,12 +73,12 @@ var serializer = new SystemTextJsonInfoCarrierSerializer(
 | | Default | Why |
 |---|---|---|
 | `MaxRequestBytes` | 64 MiB (`InfoCarrierPayloadLimits.DefaultMaxRequestBytes`) | An unauthenticated peer making your server allocate is the threat. No legitimate query tree comes near this. |
-| `MaxResponseBytes` | `null` — no bound | You asked for the result. This library has no basis for capping how large an answer your own query may have. |
+| `MaxResponseBytes` | `null`, no bound | You asked for the result. This library has no basis for capping how large an answer your own query may have. |
 
 Pass `null` to opt out of a bound. It is spelled as an explicit `null` rather than as a very large
 number so that opting out is visible in your code.
 
-Setting `MaxResponseBytes` on the client is a paging policy, not a security control — a useful one
+Setting `MaxResponseBytes` on the client is a paging policy rather than a security control, a useful one
 if you want a runaway query to fail loudly rather than exhaust memory.
 
 **The server has its own serializer with its own limits.** Both halves deserialize, so both need
@@ -94,7 +94,7 @@ optionsBuilder
     .LogTo(Console.WriteLine, LogLevel.Information);
 ```
 
-To see the payloads themselves, decorate the transport — that is what the sample's wire inspector
+To see the payloads themselves, decorate the transport. That is what the sample's wire inspector
 is. See [Custom transports](transports.md).
 
 ## The internal service provider
@@ -115,7 +115,7 @@ DbContextOptions options = new DbContextOptionsBuilder<ShopContext>()
 ```
 
 `AddEntityFrameworkInfoCarrier()` registers everything the provider needs, including the value
-mappers that ship with it. **Build the provider once and share it** — EF caches services on it, and
+mappers that ship with it. Build the provider once and share it: EF caches services on it, and
 a new one per context is a leak. If you do not need either feature, do not do this: the default
 path builds and caches the service provider for you.
 

--- a/website/docs/configuration/server.md
+++ b/website/docs/configuration/server.md
@@ -22,20 +22,20 @@ app.MapInfoCarrier();
 
 ## The registrations, one at a time
 
-**`AddDbContext<ShopContext>`** — your context on your real provider. InfoCarrier never sees the
-connection string.
+`AddDbContext<ShopContext>` registers your context on your real provider. InfoCarrier never sees
+the connection string.
 
-**`AddScoped<DbContext>`** — the server resolves the context per request as the base type
+`AddScoped<DbContext>` matters because the server resolves the context per request as the base type
 `DbContext`, so the base type has to resolve. Without this line, every request fails with a
 service-resolution error.
 
-**`IInfoCarrierSerializer`** — the same format the client uses. Both ends must agree.
+`IInfoCarrierSerializer` is the same format the client uses. Both ends must agree.
 
-**`IInfoCarrierServer`** — `InProcessInfoCarrierServer` executes a request against a `DbContext`
+`IInfoCarrierServer` is where `InProcessInfoCarrierServer` executes a request against a `DbContext`
 resolved from this service provider. *In-process* means it runs in the same process as the database
-connection; it is the normal implementation, not a test double.
+connection. It is the normal implementation, and not a test double.
 
-**`AddInfoCarrierStandardValueMappers()`** — the mappers for BCL types the wire cannot walk
+`AddInfoCarrierStandardValueMappers()` adds the mappers for BCL types the wire cannot walk
 (`IPAddress` and `Uri`). The client gets these automatically; a server builds its own service
 collection, so it has to ask. A type mapped on one side only is worse than one mapped on neither.
 See [Value mappers](value-mappers.md).
@@ -56,7 +56,7 @@ app.MapInfoCarrier()
    .WithName("InfoCarrier");
 ```
 
-Whatever route you choose, the client's transport must name the same one — see
+Whatever route you choose, the client's transport must name the same one. See
 [Configuring the client](client.md#the-http-transport).
 
 ## Payload limits
@@ -71,18 +71,18 @@ builder.Services.AddSingleton<IInfoCarrierSerializer>(
 ```
 
 A query tree is kilobytes, and a `SaveChanges` request is bounded by the graph the client tracked,
-so a low ceiling is usually safe. Cap the request bytes at your gateway too — this bound is the
-last line, not the first.
+so a low ceiling is usually safe. Cap the request bytes at your gateway too. This bound is the last
+line of defence rather than the first.
 
 ## Context lifetime
 
-`InProcessInfoCarrierServer` takes a **fresh scope per request**, so every request gets a clean
+`InProcessInfoCarrierServer` takes a fresh scope per request, so every request gets a clean
 change tracker. That is deliberate: a client request is self-contained, carrying the state the
 server needs to act on it, and leftover tracked entities from a previous request would collide with
 the next one.
 
 The exception is a transaction. `BeginTransaction` pins one context, and its connection, until the
-commit or rollback — which is why transactions should be short. See
+commit or rollback, which is why transactions should be short. See
 [Transactions](../guide/transactions.md).
 
 ## Query filters are your authorization boundary
@@ -108,23 +108,23 @@ just work arriving at your context.
 
 Nothing an application registers on the *client* is forwarded to the server, and nothing the server
 registers reaches the client. The two are separate EF Core instances and either may have hooks of
-its own — which is exactly what you want when the server is the side that must not be bypassed.
+its own, which is what you want when the server is the side that must not be bypassed.
 
 ## Model parity
 
 Both halves build a model from the same `DbContext` source, and the wire names entity types and
 properties. Two rules follow:
 
-- **Deploy both halves together** when the model changes. A property the client names and the
-  server does not know is a failed request.
-- **If a model-shaping option is enabled on one side, enable it on the other.**
-  `UseLazyLoadingProxies()` is the common example — it adds a convention, so it belongs on both, or
-  neither. (A browser client is the deliberate exception; see
-  [Blazor WebAssembly](../platforms/blazor-webassembly.md).)
+Deploy both halves together when the model changes. A property the client names and the server does
+not know is a failed request.
+
+If a model-shaping option is enabled on one side, enable it on the other. `UseLazyLoadingProxies()`
+is the common example: it adds a convention, so it belongs on both or neither. A browser client is
+the deliberate exception; see [Blazor WebAssembly](../platforms/blazor-webassembly.md).
 
 ## Health of the endpoint
 
 `MapInfoCarrier` answers a malformed body, or a client speaking a different protocol version, with
-`400` and a plain-text message naming the problem — no stack trace and no server paths. Anything
+`400` and a plain-text message naming the problem, with no stack trace and no server paths. Anything
 the server *ran* and that failed comes back inside a normal response as a fault, so your client sees
 an exception rather than an HTTP error; see [Handling errors](../guide/errors.md).

--- a/website/docs/configuration/transports.md
+++ b/website/docs/configuration/transports.md
@@ -59,7 +59,7 @@ per-request telemetry.
 ## In-process
 
 For tests, or for a client and server that live in the same process, hand the envelope straight to
-the server. Serializing both ways keeps the test honest — nothing travels by reference that would
+the server. Serializing both ways keeps the test honest, because nothing travels by reference that would
 not survive HTTP:
 
 ```csharp
@@ -113,7 +113,7 @@ public sealed class MyTransport(IMyChannel channel, IInfoCarrierSerializer seria
 Three rules the HTTP transport follows and yours should:
 
 1. **Pass the cancellation token through.** A cancelled request is the caller's signal.
-2. **Throw `InfoCarrierTransportException` for a failure of the journey** — unreachable server,
+2. Throw `InfoCarrierTransportException` for a failure of the journey: unreachable server,
    malformed answer, protocol error. Do not let a raw `JsonException` or an `HttpRequestException`
    surface: that is a lie about where the fault is. A failure the *server* reported is not this; it
    arrives inside the envelope as data.
@@ -126,8 +126,8 @@ The server half is whatever hosts your protocol, ending in a call to
 
 ## A different serializer
 
-`IInfoCarrierSerializer` is four methods — `Serialize`, `Deserialize`, and their async
-counterparts — over a `byte[]`. The library never assumes JSON. Implement it for MessagePack or
+`IInfoCarrierSerializer` is four methods over a `byte[]`: `Serialize`, `Deserialize`, and their
+async counterparts. The library never assumes JSON. Implement it for MessagePack or
 protobuf if the payload size matters to you, and register the same implementation on **both**
 halves.
 

--- a/website/docs/configuration/value-mappers.md
+++ b/website/docs/configuration/value-mappers.md
@@ -7,7 +7,7 @@ is the seam for those.
 ## When you need one
 
 The wire's default handling of a non-primitive value is to walk its public readable members. That is
-right for an anonymous type, a record or a DTO — and wrong for a type whose members are *computed*:
+right for an anonymous type, a record or a DTO, and wrong for a type whose members are *computed*:
 
 - `NetTopologySuite.Geometries.Geometry` exposes `Boundary` and `Envelope`, both of which return
   geometries. Walking one recurses until the stack overflows.
@@ -29,7 +29,7 @@ builder.Services.AddInfoCarrierStandardValueMappers();
 ```
 
 A geometry mapper is deliberately *not* in the box: shipping one would put a NetTopologySuite
-dependency in the package for a type most callers never use. Spatial types are fully supported —
+dependency in the package for a type most callers never use. Spatial types are fully supported;
 you supply the mapper, which is about thirty lines. There is a worked one in the repository's test
 utilities.
 
@@ -85,7 +85,7 @@ public sealed class MoneyValueMapper : IInfoCarrierValueMapper
 1. Declining is how a mapper says "not mine". A mapper that returns `true` **must** produce a
    non-null wire value; claiming a value and producing nothing is an error.
 2. **After a serialization round trip a wire primitive arrives as a `JsonElement`**, not as the CLR
-   type that was written. Convert it rather than casting it — this is the mistake to expect.
+   type that was written. Convert it rather than casting it. This is the mistake to expect.
 
 The wire value must be one of the primitives the serializer knows: in practice a `string` or a
 `byte[]`.
@@ -144,5 +144,5 @@ modelBuilder.Entity<Customer>()
 ```
 
 Both halves build the model from the same source, so both derive the same conversion. Reach for a
-mapper when there is no converter — or when the CLR type is dangerous to walk regardless of how it
+mapper when there is no converter, or when the CLR type is dangerous to walk regardless of how it
 is stored.

--- a/website/docs/getting-started/first-app.md
+++ b/website/docs/getting-started/first-app.md
@@ -6,7 +6,7 @@ and runs.
 ## 1. The shared model
 
 Put the entity classes and the `DbContext` in a project both halves reference. This is not a
-convention — it is what makes the wire format work. The payload names entity types and properties,
+convention: it is what makes the wire format work. The payload names entity types and properties,
 and the two ends resolve those names against **their own** models, so the models must agree.
 Sharing the source makes that true by construction.
 
@@ -87,7 +87,7 @@ app.Run();
 ```
 
 `InProcessInfoCarrierServer` is the piece that executes a request against a real `DbContext`. The
-name says *in-process* because it runs the query in the same process as the database connection —
+name says *in-process* because it runs the query in the same process as the database connection;
 it is the normal server-side implementation, not a test double.
 
 ## 3. The client
@@ -116,7 +116,7 @@ Three objects, each replaceable:
 | | |
 |---|---|
 | `SystemTextJsonInfoCarrierSerializer` | turns envelopes into bytes. Source-generated, so it works in a trimmed build. |
-| `HttpInfoCarrierTransport` | posts the bytes and reads the answer. One method — see [Custom transports](../configuration/transports.md). |
+| `HttpInfoCarrierTransport` | posts the bytes and reads the answer. One method; see [Custom transports](../configuration/transports.md). |
 | `TransportInfoCarrierClient` | the client the provider talks to. |
 
 In a DI application, register them instead:
@@ -165,9 +165,9 @@ await context.SaveChangesAsync();   // one round trip, two rows
 
 Read on:
 
-- [Querying](../guide/querying.md) — what runs where, and how to tell.
-- [Saving changes](../guide/saving-changes.md) — units of work, graphs, generated keys.
-- [Transactions](../guide/transactions.md) — including one transaction across two contexts.
+- [Querying](../guide/querying.md): what runs where, and how to tell.
+- [Saving changes](../guide/saving-changes.md): units of work, graphs, generated keys.
+- [Transactions](../guide/transactions.md): including one transaction across two contexts.
 
 ## Testing without a network
 

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -22,7 +22,7 @@ Shop.Server     ── ASP.NET Core + a real EF Core provider       → Shop.Sha
 ```
 
 The `DbContext` and the entity classes are **shared source**. Both halves build the same model from
-the same code, which is what makes the wire format meaningful — see
+the same code, which is what makes the wire format meaningful. See
 [Your first client and server](first-app.md).
 
 ## Installing
@@ -30,7 +30,7 @@ the same code, which is what makes the wire format meaningful — see
 === "dotnet CLI"
 
     ```bash
-    # In the client project — and in the server project too.
+    # In the client project, and in the server project too.
     dotnet add package InfoCarrier.Core --version 10.0.0-preview.1
 
     # In the server project only.
@@ -53,13 +53,13 @@ the same code, which is what makes the wire format meaningful — see
     Install-Package InfoCarrier.Core.AspNetCore -Version 10.0.0-preview.1
     ```
 
-!!! danger "Always name the version — an unversioned install gets the *previous generation*"
+!!! danger "Always name the version: an unversioned install gets the *previous generation*"
 
     `InfoCarrier.Core` has been on nuget.org since **1.0**, and its newest **stable** release is
     `3.1.1`, built for **EF Core 3.1**. NuGet prefers a stable release over a prerelease, so:
 
     ```bash
-    dotnet add package InfoCarrier.Core              # installs 3.1.1 — NOT this library
+    dotnet add package InfoCarrier.Core              # installs 3.1.1, NOT this library
     dotnet add package InfoCarrier.Core --version 10.0.0-preview.1   # correct
     dotnet add package InfoCarrier.Core --prerelease                 # also correct
     ```
@@ -68,13 +68,13 @@ the same code, which is what makes the wire format meaningful — see
     an EF Core seven majors old. This stays true until a stable `10.x` ships.
 
     `InfoCarrier.Core.AspNetCore` is new in this generation and has no older version to fall back
-    to — but pin it anyway, so the two halves cannot drift apart.
+    to, but pin it anyway so the two halves cannot drift apart.
 
     The same applies to Central Package Management: pin `10.0.0-preview.1` in
     `Directory.Packages.props`.
 
     If you are moving an application off `3.1.1`, read
-    [Upgrading from 3.1](upgrading-from-3-1.md) — the model carries over, the wiring does not.
+    [Upgrading from 3.1](upgrading-from-3-1.md). The model carries over; the wiring does not.
 
 Both packages ship symbol packages and SourceLink, so you can step into the provider from a
 debugger with no extra configuration.
@@ -97,12 +97,12 @@ Both packages land in `artifacts/pack`; every other project in the solution opts
 |---|---|
 | Runtime | .NET 10 |
 | EF Core | 10.0 |
-| Server-side provider | any — SQL Server, PostgreSQL, SQLite, InMemory … |
+| Server-side provider | any: SQL Server, PostgreSQL, SQLite, InMemory … |
 | Client platforms | anywhere .NET 10 runs, including Blazor WebAssembly |
 
 The server's provider is entirely your choice: it is an ordinary EF Core application, and
 InfoCarrier.Core never sees the connection. The one platform with constraints of its own is the
-browser — see [Blazor WebAssembly](../platforms/blazor-webassembly.md).
+browser. See [Blazor WebAssembly](../platforms/blazor-webassembly.md).
 
 ## Versioning
 

--- a/website/docs/getting-started/samples.md
+++ b/website/docs/getting-started/samples.md
@@ -1,7 +1,8 @@
 # Run the samples
 
 The repository carries a Northwind sample: one shared model, one SQLite-backed server, and two
-clients that are the same client twice — a browser and a console. Neither has a connection string.
+clients that are the same client twice, one a browser and one a console. Neither has a connection
+string.
 
 ```bash
 git clone https://github.com/azabluda/InfoCarrier.Core.git
@@ -18,13 +19,13 @@ dotnet run --project samples/Northwind.Server
 
 Open <http://localhost:5199>. You get a Blazor WebAssembly client whose `DbContext` has no
 database, and a **wire inspector** down the right-hand side showing every round trip: the
-operation, the size each way, how long it took, and the decoded payload — including the expression
+operation, the size each way, how long it took, and the decoded payload, including the expression
 tree, unpacked out of the base64 it travels in.
 
 Three pages, deliberately ordinary:
 
 **Customers** is a grid. Click a header to sort, open a column filter to narrow it, page through
-the rest. There is no *Run* button because there is nothing to run — the sort, the filter and the
+the rest. There is no *Run* button because there is nothing to run: the sort, the filter and the
 paging are already part of the expression tree the page sends. Filtering `Country` for *Germany*
 takes 65 rows to 8, and the panel shows the `Where` crossing the wire.
 
@@ -34,7 +35,7 @@ The master list is a projection over a join, so it shows *Alfreds Futterkiste* r
 and the server does the joining.
 
 **Transfer** moves an order to another customer and takes a unit off a product's stock, both inside
-one transaction — with a tickbox that makes the second save fail on the server's database, so you
+one transaction, with a tickbox that makes the second save fail on the server's database, so you
 can watch the rollback. Both figures are read back afterwards through a fresh context, so what you
 see is the server's answer rather than the local change tracker agreeing with itself.
 
@@ -58,7 +59,7 @@ interesting part: touching a navigation costs a request *when it is touched*, an
 !!! tip "Delete `northwind.db` first if you want the transcript's exact numbers"
 
     The browser pages write to the same store, and the Transfer page moves an order to a different
-    customer. A store that has been clicked through answers differently — which is the
+    customer. A store that has been clicked through answers differently, which is the
     demonstration working, not the numbers being wrong.
 
 The console client **lazy-loads normally**, unlike the browser one. It is not WebAssembly, so a

--- a/website/docs/getting-started/upgrading-from-3-1.md
+++ b/website/docs/getting-started/upgrading-from-3-1.md
@@ -5,7 +5,7 @@ the `1.0`–`3.1` line and almost nothing else: the expression serializer, the w
 client/server split and the security model are all new code.
 
 **Your `DbContext` and your entity classes are unchanged.** Everything around them moves, and it
-will not compile until you have moved it. That is deliberate — the three public interfaces kept
+will not compile until you have moved it. That is deliberate: the three public interfaces kept
 their names and changed their shapes, so an old implementation fails to build rather than building
 and misbehaving.
 
@@ -16,7 +16,7 @@ and misbehaving.
     application, this upgrade is a port of the client first.
 
     **Name the version when you install.** `3.1.1` is still the newest *stable* release on
-    nuget.org, so an unversioned `dotnet add package` keeps giving you the old line — see
+    nuget.org, so an unversioned `dotnet add package` keeps giving you the old line. See
     [Installation](installation.md#installing).
 
 ## What did not change
@@ -42,8 +42,8 @@ and misbehaving.
 ```
 
 `Remote.Linq` and `Aqua` are gone; the only remaining dependency is
-`Microsoft.EntityFrameworkCore`. If you referenced either package *directly* — for example to
-configure a serializer — remove it. See [Installation](installation.md) for why the split is
+`Microsoft.EntityFrameworkCore`. If you referenced either package *directly*, for example to
+configure a serializer, remove it. See [Installation](installation.md) for why the split is
 where it is.
 
 ### 2. `UseInfoCarrierClient` became `UseInfoCarrier`
@@ -66,7 +66,7 @@ optionsBuilder.UseInfoCarrier(client);
 
 This is the largest saving, and the largest diff. `3.1` shipped **no** transport: every
 application implemented `IInfoCarrierClient` itself, and the samples that came with it ran to
-about a hundred lines each — an `HttpClient`, hand-configured Newtonsoft settings, one route per
+about a hundred lines each: an `HttpClient`, hand-configured Newtonsoft settings, one route per
 operation, and a cache keyed on a transaction-id header to carry transactions between calls.
 
 All of that is now three objects:
@@ -82,8 +82,9 @@ IInfoCarrierClient client = new TransportInfoCarrierClient(
     serializer);
 ```
 
-Delete your old client implementation. If you are not on HTTP — WCF, ServiceStack, a message bus,
-a direct in-process call — you now implement `IInfoCarrierTransport`, which is **one method** that
+Delete your old client implementation. If you are not on HTTP, whether that is WCF, ServiceStack, a
+message bus or a direct in-process call, you now implement `IInfoCarrierTransport`, which is one
+method that
 moves an envelope and interprets nothing, rather than the whole client interface. See
 [Custom transports](../configuration/transports.md).
 
@@ -118,7 +119,7 @@ builder.Services
 app.MapInfoCarrier();
 ```
 
-`AddInfoCarrierServer()` is gone — register `InProcessInfoCarrierServer` yourself, as above.
+`AddInfoCarrierServer()` is gone. Register `InProcessInfoCarrierServer` yourself, as above.
 `AddScoped<DbContext>` is the line people miss: the server resolves your context by its base type.
 Full detail in [Configuring the server](../configuration/server.md).
 
@@ -135,12 +136,12 @@ implementations and touch none of them.
 
 Two consequences worth calling out:
 
-- **The client contract is async-only.** `3.1`'s sync members existed to satisfy EF Core's
-  synchronous API and were routinely implemented with `.Result` or `.Wait()` — the samples carried
+- The client contract is async-only. `3.1`'s sync members existed to satisfy EF Core's synchronous
+  API and were routinely implemented with `.Result` or `.Wait()`; the samples carried
   a comment linking to the deadlock that causes. Synchronous `DbContext` calls still work; they no
   longer oblige you to write a blocking transport.
-- **Value mappers moved namespace**, to `InfoCarrier.Core.ValueMapping`, and no longer name a
-  serializer type in their signature. Two are now built in — `IPAddress` and `Uri` — so a mapper
+- Value mappers moved to the `InfoCarrier.Core.ValueMapping` namespace, and no longer name a
+  serializer type in their signature. Two are now built in, `IPAddress` and `Uri`, so a mapper
   you wrote for either can simply be deleted. See
   [Value mappers](../configuration/value-mappers.md).
 
@@ -150,21 +151,21 @@ Two consequences worth calling out:
 |---|---|
 | `InfoCarrier.Core.Client` | `InfoCarrier.Core` |
 | `InfoCarrier.Core.Server` | `InfoCarrier.Core` |
-| `InfoCarrier.Core.Common` | `InfoCarrier.Core.Common` — the wire contracts, unchanged in role |
+| `InfoCarrier.Core.Common` | `InfoCarrier.Core.Common`, the wire contracts, unchanged in role |
 | `InfoCarrier.Core.Common.ValueMapping` | `InfoCarrier.Core.ValueMapping` |
-| — | `InfoCarrier.Core.AspNetCore` |
+| none | `InfoCarrier.Core.AspNetCore` |
 
 ## What you get that 3.1 could not do
 
-Most of this is EF Core 10 rather than InfoCarrier, which is rather the point — the provider
+Most of this is EF Core 10 rather than InfoCarrier, which is the point: the provider
 inherits what the version underneath it can express.
 
 - Complex types, and JSON-mapped owned collections
 - `ExecuteUpdate` and `ExecuteDelete`
 - Many-to-many without an explicit join entity
-- Savepoints — `3.1` had begin, commit and rollback only
+- Savepoints. `3.1` had begin, commit and rollback only
 - Spatial types without data loss: Z and M ordinates survive the round trip
-- Blazor WebAssembly, published trimmed — with
+- Blazor WebAssembly, published trimmed, with
   [one constraint worth reading first](../platforms/blazor-webassembly.md)
 - A stated, tested [security boundary](../security.md) on the server, which `3.1` did not have
 
@@ -180,5 +181,5 @@ inherits what the version underneath it can express.
 8. Read [Limitations](../limitations.md) before you ship.
 
 If something in your application has no route across, please
-[open an issue](https://github.com/azabluda/InfoCarrier.Core/issues) — while this is a preview,
+[open an issue](https://github.com/azabluda/InfoCarrier.Core/issues). While this is a preview,
 that feedback still changes the shape of the API.

--- a/website/docs/guide/errors.md
+++ b/website/docs/guide/errors.md
@@ -25,7 +25,7 @@ catch (DbUpdateException ex)
 ```
 
 Deeper in the chain, where the original exception is a type your client has no reason to reference
-— a `SqliteException`, a `SqlException`, a driver's own type — it arrives as
+such as a `SqliteException`, a `SqlException` or a driver's own type, it arrives as
 `InfoCarrierServerException`, which still names what the server actually threw:
 
 ```csharp
@@ -39,7 +39,7 @@ catch (DbUpdateException ex) when (ex.InnerException is InfoCarrierServerExcepti
 ```
 
 Making every client reference every database driver, just so a `catch` clause could name the type,
-would be a worse trade than losing the name from the clause — so the name lives in a property
+would be a worse trade than losing the name from the clause, so the name lives in a property
 instead.
 
 A real chain from a foreign-key violation looks like this:
@@ -52,7 +52,7 @@ DbUpdateException                     the client's own, from EF
 
 ### The server's stack trace
 
-It is preserved, and deliberately not spliced into the client-side exception's own stack — that
+It is preserved, and deliberately not spliced into the client-side exception's own stack, because that
 would be lying about where your client is. It travels in `Exception.Data`:
 
 ```csharp
@@ -80,7 +80,7 @@ catch (InfoCarrierTransportException ex)
 }
 ```
 
-The underlying failure — an `HttpRequestException`, a serialization error — is kept as
+The underlying failure, such as an `HttpRequestException` or a serialization error, is kept as
 `InnerException`, because it names the layer that actually failed. When the server answers with a
 non-success status, the message carries the status code **and the response body**: a bare status
 code is indistinguishable from a dozen unrelated causes to whoever has to diagnose it.
@@ -105,14 +105,14 @@ catch (Exception ex) when (ex is InfoCarrierTransportException
 ## Do not match on message text
 
 Where a query cannot be translated, this provider throws `InvalidOperationException`, exactly as EF
-Core does — but the wording differs from other providers' in a couple of cases. Message text is not
+Core does, but the wording differs from other providers' in a couple of cases. Message text is not
 a supported contract on **any** EF Core provider; catch the type. See
 [Limitations](../limitations.md).
 
 ## Cancellation
 
 Every async method takes a `CancellationToken` and passes it through to the transport. A cancelled
-request raises `OperationCanceledException` and is never reported as a transport failure — it is
+request raises `OperationCanceledException` and is never reported as a transport failure. It is
 your own signal, not something that went wrong.
 
 ```csharp
@@ -124,7 +124,7 @@ List<Customer> customers = await context.Customers.ToListAsync(cts.Token);
 ## What the server does not tell you
 
 Where the server maps a failure into a fault, it sends the type name, the message, the inner chain
-and the stack trace. It does not send anything else about itself — no server paths beyond what a
+and the stack trace. It does not send anything else about itself, and no server paths beyond what a
 stack trace contains, no connection strings, no configuration. If your exception messages carry
 information a client should not see, that is worth reviewing on the server: see
 [Security](../security.md).

--- a/website/docs/guide/loading-related-data.md
+++ b/website/docs/guide/loading-related-data.md
@@ -3,7 +3,7 @@
 Every way EF Core loads a navigation works here. The difference is that each one has a visible
 price: a round trip.
 
-## Eager loading — one round trip
+## Eager loading: one round trip
 
 `Include` is part of the query, so the related rows arrive with the principals:
 
@@ -28,7 +28,7 @@ List<Customer> customers = await context.Customers
 **This is the one to reach for by default.** One request that returns a graph beats several
 requests that return the same graph in pieces.
 
-## Explicit loading — one round trip, when you ask
+## Explicit loading: one round trip, when you ask
 
 Load a navigation on an entity you already have:
 
@@ -51,7 +51,7 @@ int count = await context.Entry(customer)
     .CountAsync(o => o.Freight > 50m);
 ```
 
-## Lazy loading — a round trip per touch
+## Lazy loading: a round trip per touch
 
 Lazy loading works, through EF Core's proxies package as usual:
 
@@ -69,10 +69,10 @@ int lines = order.Lines.Count;              // and its lines now
 
 Two things to weigh before enabling it:
 
-- **Every touched navigation is a request.** A loop over 100 orders that reads `order.Customer`
+- Every touched navigation is a request. A loop over 100 orders that reads `order.Customer`
   makes 100 requests. This is the classic N+1, and over a network it is much more expensive than
   it is against a local database.
-- **A navigation getter is synchronous**, so a lazy load blocks the calling thread on the round
+- A navigation getter is synchronous, so a lazy load blocks the calling thread on the round
   trip. In a UI application that means loading off the UI thread or accepting the freeze.
 
 If you enable proxies, enable them on **both** halves. The two models have to agree about
@@ -106,4 +106,4 @@ var summary = await context.Orders
 ```
 
 The join happens on the server, and what comes back is three values per row rather than two whole
-entities. For a read-only grid this is usually the right shape — combine it with `AsNoTracking`.
+entities. For a read-only grid this is usually the right shape; combine it with `AsNoTracking`.

--- a/website/docs/guide/querying.md
+++ b/website/docs/guide/querying.md
@@ -21,8 +21,9 @@ Three cases, and you can usually tell which one you are in by looking at the pro
 
 ### The whole query goes
 
-If everything in the query is something the server can execute — properties of mapped entities,
-operators, the LINQ methods EF translates — the entire tree is sent and the server answers with
+If everything in the query is something the server can execute, such as properties of mapped
+entities, operators and the LINQ methods EF translates, the entire tree is sent and the server
+answers with
 rows or a scalar.
 
 ```csharp
@@ -39,8 +40,8 @@ An aggregate returns a number, not the rows behind it.
 
 ### The query is split
 
-If the projection contains code the server cannot run — one of your own methods, a locally defined
-type, formatting — the query is **cut at that point**. The server runs the part that reaches the
+If the projection contains code the server cannot run, such as one of your own methods, a locally
+defined type or formatting, the query is cut at that point. The server runs the part that reaches the
 data; the client runs the projection over what comes back.
 
 ```csharp
@@ -60,7 +61,7 @@ var report = await context.Orders
 
 This is the behaviour you want: the filter is not dragged back to the client just because the
 projection cannot be translated. It also means an unfiltered query with a client-side projection
-fetches **everything** — put the `Where` in before you worry about the `Select`.
+fetches everything, so put the `Where` in before you worry about the `Select`.
 
 !!! warning "A local function cannot appear in a query"
 
@@ -75,13 +76,13 @@ fetches **everything** — put the `Where` in before you worry about the `Select
 ### The query cannot be translated
 
 Where EF Core itself would refuse a query, this provider refuses it too, with an
-`InvalidOperationException` — the same exception type EF throws. **Catch the type, never match on
+`InvalidOperationException`, the same exception type EF throws. **Catch the type, never match on
 the message**: message text is not a supported contract on any EF Core provider, and a couple of
 messages here differ from other providers' by wording. See [Limitations](../limitations.md).
 
 ## Tracking
 
-Change tracking works exactly as it does with any provider — the identity map, navigation fix-up
+Change tracking works exactly as it does with any provider: the identity map, navigation fix-up
 and all. For a read-only screen, opt out:
 
 ```csharp
@@ -117,7 +118,8 @@ int matching = await query.CountAsync();
 ```
 
 1. **Order before you page, and order on the entity.** If you sort a client-side projection
-   instead, the server pages an unordered set and the client sorts the page — one page of the wrong
+   instead, the server pages an unordered set and the client sorts the page, giving one page of the
+   wrong
    rows, in the right order. The sample's Customers grid is built this way for exactly this reason.
 
 ## Bulk operations
@@ -135,12 +137,12 @@ int deleted = await context.Orders
 ```
 
 Both return the number of rows affected. As with any EF Core provider, neither updates your local
-change tracker — the entities the client already holds keep their old values until reloaded.
+change tracker, so the entities the client already holds keep their old values until reloaded.
 
 ## What is not part of the surface
 
-The client has no database and no relational provider, so relational-only APIs — `FromSql`,
-`Database.ExecuteSqlRaw`, `GetDbTransaction`, migrations, `EnsureCreated` — are not what this
+The client has no database and no relational provider, so relational-only APIs (`FromSql`,
+`Database.ExecuteSqlRaw`, `GetDbTransaction`, migrations, `EnsureCreated`) are not what this
 provider offers. Schema management belongs on the server, where the real provider is, and so does
 any raw SQL: expose it as a server-side operation of your own rather than sending SQL from a
 client.
@@ -148,7 +150,7 @@ client.
 ## Two things to keep in mind
 
 **Every materialized query is a network round trip.** `ToListAsync`, `FirstOrDefaultAsync`,
-`CountAsync` — each is a request. A loop that queries per item is a loop that makes one request per
+`CountAsync`, and each is a request. A loop that queries per item is a loop that makes one request per
 item. Compose the query instead, or fetch what you need with `Include`.
 
 **Result size is your query's business.** There is a default size bound on requests *towards* the

--- a/website/docs/guide/saving-changes.md
+++ b/website/docs/guide/saving-changes.md
@@ -35,7 +35,7 @@ await context.SaveChangesAsync();
 Console.WriteLine(order.Id);   // the key the server's database issued
 ```
 
-The same applies to any store-generated property — computed columns, default values, concurrency
+The same applies to any store-generated property: computed columns, default values, concurrency
 tokens.
 
 !!! note "Before the save, read the key from the entry"
@@ -79,7 +79,7 @@ context.Orders.Remove(order);
 await context.SaveChangesAsync();
 ```
 
-To delete without loading the row first, use `ExecuteDeleteAsync` — see
+To delete without loading the row first, use `ExecuteDeleteAsync`. See
 [Querying](querying.md#bulk-operations).
 
 ## Concurrency
@@ -118,6 +118,6 @@ also what stops a client from writing anything the server's model does not expos
 
 ## Errors
 
-A failure on the server — a constraint violation, a trigger, a validation exception in an
-interceptor — arrives on the client as the exception EF would have thrown locally, with its message
+A failure on the server, whether a constraint violation, a trigger or a validation exception in an
+interceptor, arrives on the client as the exception EF would have thrown locally, with its message
 and inner chain preserved. See [Handling errors](errors.md).

--- a/website/docs/guide/transactions.md
+++ b/website/docs/guide/transactions.md
@@ -55,14 +55,14 @@ await transaction.CommitAsync();
 `RollbackToSavepointAsync` undoes the work after the savepoint and leaves the transaction open.
 `ReleaseSavepointAsync` discards the savepoint and keeps the work.
 
-A store that has no savepoints — EF Core's InMemory provider, for instance — reports that rather
+A store that has no savepoints, such as EF Core's InMemory provider, reports that rather
 than failing halfway. `transaction.SupportsSavepoints` answers before you try, and the answer comes
 from the server's store rather than from a guess on the client.
 
 ## Two contexts, one transaction
 
-Sometimes one screen needs several `DbContext` instances — a grid that refreshes on its own, a
-detail pane holding a unit of work — and the writes have to land together. A second context joins
+Sometimes one screen needs several `DbContext` instances, such as a grid that refreshes on its own
+and a detail pane holding a unit of work, and the writes have to land together. A second context joins
 the first one's transaction:
 
 ```csharp
@@ -83,7 +83,7 @@ await transaction.CommitAsync();                          // (2)
    There the shared thing is a `DbTransaction` on a connection; here it is the server's token,
    which is what makes sharing possible across a transport that may be stateless.
 2. **The joining context does not own the transaction.** Ending it detaches `second` and leaves the
-   transaction to whoever began it. Commit through the context that began it — two contexts able to
+   transaction to whoever began it. Commit through the context that began it, because two contexts able to
    commit the same transaction would make the outcome depend on disposal order.
 
 `UseInfoCarrierTransaction` is an extension on `DatabaseFacade`, in the `InfoCarrier.Core`
@@ -108,6 +108,6 @@ await strategy.ExecuteAsync(async () =>
 ## What is not available
 
 `IDbContextTransaction.GetDbTransaction()` and anything else that hands you a `DbTransaction` are
-relational APIs, and the client is not relational — there is no local connection to hand out. Ambient
+relational APIs, and the client is not relational, so there is no local connection to hand out. Ambient
 `TransactionScope` is likewise not part of this provider's surface. The server's token is the whole
 of what can be shared, which is what `UseInfoCarrierTransaction` takes.

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -3,8 +3,8 @@
 **Use the full power of Entity Framework Core in a client application that has no database.**
 
 InfoCarrier.Core is an Entity Framework Core provider you put on the *client* side of a multi-tier
-application. Your client gets a real `DbContext` — LINQ, change tracking, the identity map,
-navigation fix-up, lazy loading, transactions — with no connection string and no database driver.
+application. Your client gets a real `DbContext` with LINQ, change tracking, the identity map,
+navigation fix-up, lazy loading and transactions, but no connection string and no database driver.
 Queries and units of work travel to your application server and run there against the real
 database.
 
@@ -24,13 +24,13 @@ await context.SaveChangesAsync();   // one unit of work, executed on the server
 ```
 
 That query is not evaluated on the client. It crosses the wire as an expression tree, and your
-server runs it against SQL Server, PostgreSQL, SQLite — whatever provider the server uses.
+server runs it against SQL Server, PostgreSQL, SQLite, or whatever provider the server uses.
 
 <div class="grid cards" markdown>
 
 -   :material-rocket-launch: **[Install it](getting-started/installation.md)**
 
-    Two packages on nuget.org, split on the only line that costs anything.
+    Two packages on nuget.org, and what each one costs you.
 
 -   :material-code-braces: **[Build a client and a server](getting-started/first-app.md)**
 
@@ -48,13 +48,12 @@ server runs it against SQL Server, PostgreSQL, SQLite — whatever provider the 
 
 ## Why you might want this
 
-- **Your rich client needs more than a REST façade.** An endpoint per screen and a DTO per
-  endpoint is the cost this removes. The client composes the query it actually needs.
-- **You already know the API.** It is EF Core. There is nothing new to learn on the client.
-- **One model, not two.** The `DbContext` and the entity classes are shared source between client
-  and server. No DTO layer to keep in sync.
-- **The transport is yours.** HTTP ships in the box, but shipping requests is one interface with
-  one method — gRPC, a message bus or a direct in-process call are each a small class.
+Your client writes the query it needs, against the same entity classes the server uses. There is no
+endpoint per screen, no DTO per endpoint, and no second set of types to keep in sync. The API is EF
+Core, so there is nothing new to learn on the client.
+
+HTTP ships in the box. To send requests over gRPC or a message bus instead, you implement one small
+interface.
 
 ## How it fits together
 
@@ -67,9 +66,9 @@ graph LR
 ```
 
 The client's `DbContext` compiles your LINQ query, decides which part of it the server can run, and
-sends that part. The server executes it **against its own model**, with its own query filters and
-its own interceptors, and sends rows back. The client materializes them into tracked entities and
-runs whatever was left of the query locally.
+sends that part. The server executes it against its own model, with its own query filters and its
+own interceptors, and sends rows back. The client materializes them into tracked entities and runs
+whatever was left of the query locally.
 
 `SaveChanges` works the same way: the client's change tracker produces a set of change entries, the
 server replays them against a real `DbContext`, and store-generated values come back.
@@ -80,15 +79,9 @@ Queries, the client/server split of a projection, `SaveChanges` including many-t
 lazy loading, explicit loading, transactions with savepoints, `ExecuteUpdate`/`ExecuteDelete`,
 complex types, JSON-mapped collections, spatial types and compiled models.
 
-The provider is judged by Microsoft's own Entity Framework Core specification suite — the same
-suite EF Core's SQL Server, SQLite and InMemory providers run:
-
-```
-Total tests: 22658, Passed: 22472, Failed: 9, Skipped: 177
-```
-
-The nine are known, and every one of them is written up on the
-[limitations](limitations.md) page in terms of the code that triggers it.
+The provider is judged by Microsoft's own Entity Framework Core specification suite, the same suite
+EF Core's SQL Server, SQLite and InMemory providers run. The failures that remain are written up on
+the [limitations](limitations.md) page in terms of the code that triggers them.
 
 !!! warning "This is a preview"
 
@@ -96,12 +89,12 @@ The nine are known, and every one of them is written up on the
     dotnet add package InfoCarrier.Core --version 10.0.0-preview.1
     ```
 
-    **Name the version.** `InfoCarrier.Core` has been on nuget.org since **1.0**, and an
-    unversioned install resolves to its newest *stable* release — `3.1.1`, built for EF Core 3.1 —
-    rather than to this one. See [Installation](getting-started/installation.md).
+    **Name the version.** `InfoCarrier.Core` has been on nuget.org since 1.0, and an unversioned
+    install resolves to its newest *stable* release, `3.1.1`, which was built for EF Core 3.1. See
+    [Installation](getting-started/installation.md).
 
-    **Coming from `3.1`?** This is a rewrite and it is not backward compatible — your model
-    carries over, the wiring around it does not. See
+    **Coming from `3.1`?** This is a rewrite and it is not backward compatible. Your model carries
+    over; the wiring around it does not. See
     [Upgrading from 3.1](getting-started/upgrading-from-3-1.md).
 
     A gRPC binding and streaming results as `IAsyncEnumerable` are still to come, and both may
@@ -109,9 +102,9 @@ The nine are known, and every one of them is written up on the
 
 ## Security in one paragraph
 
-Your server executes an expression tree that arrived over the network. That is the product, and it
-is bounded deliberately: a default-deny allowlist over node kinds, types and methods, no assembly
-loaded to satisfy a payload, blocked reflection entry points, and a size bound on what will be
-deserialized. **Authentication and authorization are not in scope and remain yours** — authenticate
-the transport, and use query filters on the server's model to decide what a caller may see. The
-[security page](security.md) is the longer version.
+Your server executes an expression tree that arrived over the network. That path is bounded by a
+default-deny allowlist over node kinds, types and methods, no assembly loaded to satisfy a payload,
+blocked reflection entry points, and a size bound on what will be deserialized. Authentication and
+authorization are not in scope and remain yours: authenticate the transport, and use query filters
+on the server's model to decide what a caller may see. The [security page](security.md) is the
+longer version.

--- a/website/docs/limitations.md
+++ b/website/docs/limitations.md
@@ -1,6 +1,6 @@
 # Limitations
 
-InfoCarrier.Core runs Microsoft's own Entity Framework Core specification suite — the same suite EF
+InfoCarrier.Core runs Microsoft's own Entity Framework Core specification suite, the same suite EF
 Core's SQL Server, SQLite and InMemory providers run. This page lists **every scenario in that suite
 that does not behave the way a normal EF Core provider behaves**, so you can judge whether any of
 them affects your application.
@@ -18,7 +18,7 @@ Total tests: 22658, Passed: 22472, Failed: 9, Skipped: 177
 
 ### Inserting an entity whose complex property is a property bag
 
-**Affects you if** you map a complex property — or a complex collection — whose CLR type is
+**Affects you if** you map a complex property, or a complex collection, whose CLR type is
 `Dictionary<string, object>`. EF Core calls this a *property bag*: the shape is declared in the
 model rather than in the CLR type.
 
@@ -40,7 +40,7 @@ modelBuilder.Entity<Product>()
     });
 ```
 
-**What happens** — the insert throws:
+**What happens.** The insert throws:
 
 ```csharp
 context.Products.Add(new Product
@@ -59,7 +59,7 @@ The same applies to the collection form, `List<Dictionary<string, object>>` mapp
 by EF's suite for this shape, so treat the whole write path as unsupported rather than assuming
 update works.
 
-**Workaround** — declare the complex type as an ordinary class:
+**Workaround.** Declare the complex type as an ordinary class:
 
 ```csharp
 public class ProductSpec
@@ -81,7 +81,7 @@ modelBuilder.Entity<Product>().ComplexProperty(e => e.Spec);
 Every other complex-type shape is supported, including nested complex types and complex collections,
 as long as the type is a class rather than a dictionary.
 
-**Cause** — a defect in EF Core's own materializer, reached because this provider rebuilds entities
+**Cause.** A defect in EF Core's own materializer, reached because this provider rebuilds entities
 on the server from the values sent over the wire. Tracked upstream as
 [dotnet/efcore#36175](https://github.com/dotnet/efcore/issues/36175).
 
@@ -108,11 +108,11 @@ var report = context.Customers
     .ToList();
 ```
 
-**What happens** — the query runs and returns a result. **No EF Core provider supports this query**:
+**What happens.** The query runs and returns a result. No EF Core provider supports this query:
 SQL Server, SQLite and InMemory all reject it. Because no provider executes it, there is no reference
 answer to check this one against, so the result returned here is unverified.
 
-**Workaround** — apply `Distinct` after materialising:
+**Workaround.** Apply `Distinct` after materialising:
 
 ```csharp
 Products = o.Lines.Select(l => l.ProductName).ToList(),   // then .Distinct() in memory
@@ -128,7 +128,7 @@ and you may notice when porting code or tests.
 ### Exception message text for an untranslatable query
 
 When a query cannot be translated, this provider throws `InvalidOperationException`, exactly as EF
-Core does. **The message text may differ** in two cases — a method call inside an `ExecuteUpdate`
+Core does. **The message text may differ** in two cases: a method call inside an `ExecuteUpdate`
 property selector, and a cast to a type nothing in your model implements:
 
 ```csharp
@@ -142,7 +142,7 @@ IQueryable orders = context.Orders;
 orders.Cast<IArchivable>().FirstOrDefault();
 ```
 
-Both throw. **Catch the exception type; do not match on message text** — that is unsupported on any
+Both throw. **Catch the exception type; do not match on message text.** That is unsupported on any
 EF Core provider.
 
 ### Queries this provider answers that other providers reject
@@ -191,16 +191,16 @@ elsewhere on this site:
 
 | | |
 |---|---|
-| Relational-only APIs — `FromSql`, `ExecuteSqlRaw`, `GetDbTransaction`, migrations — are not part of this provider's surface | [Querying](guide/querying.md#what-is-not-part-of-the-surface) |
+| Relational-only APIs (`FromSql`, `ExecuteSqlRaw`, `GetDbTransaction`, migrations) are not part of this provider's surface | [Querying](guide/querying.md#what-is-not-part-of-the-surface) |
 | Automatic lazy loading does not work in Blazor WebAssembly | [Blazor WebAssembly](platforms/blazor-webassembly.md) |
 | Results do not stream; a query materializes into a single answer | below |
 | Authentication and authorization are yours | [Security](security.md) |
 
 ## Still to come
 
-- **A gRPC binding.** HTTP ships; gRPC is a small class you can write today against
+- A gRPC binding. HTTP ships; gRPC is a small class you can write today against
   [`IInfoCarrierTransport`](configuration/transports.md), but nothing is in the box.
-- **Streaming results as `IAsyncEnumerable`.** A query result is materialized in one response
+- Streaming results as `IAsyncEnumerable`. A query result is materialized in one response
   today, so a very large result set is a very large response. Page it.
 
 Both may change the transport interface, which is why the version still says `preview`.

--- a/website/docs/platforms/blazor-webassembly.md
+++ b/website/docs/platforms/blazor-webassembly.md
@@ -4,7 +4,7 @@ A browser client works, and it is the case this provider is most obviously *for*
 the browser, composing real LINQ, with the database behind your server. The sample's three pages
 run in WebAssembly, published trimmed.
 
-Two constraints apply, and **neither is this provider's** — they are the browser's. A console or
+Two constraints apply, and neither is this provider's. They are the browser's. A console or
 desktop client has neither.
 
 ## Automatic lazy loading is impossible
@@ -33,7 +33,7 @@ costs exactly one round trip.
 
 !!! note "The asymmetry with the server is safe"
 
-    Your **server** may still call `UseLazyLoadingProxies()` — it is not a browser. Proxies change
+    Your **server** may still call `UseLazyLoadingProxies()`, because it is not a browser. Proxies change
     how an entity is constructed on the side that enables them, and the wire carries entity type
     *names*. The sample is wired exactly this way: proxies on the server, none in the browser.
 
@@ -44,7 +44,7 @@ costs exactly one round trip.
 `dotnet ef dbcontext optimize` output cannot be loaded in WebAssembly as generated. EF initializes
 the model on a `new Thread(…, 10 MB)` to avoid stack overflow on large models
 ([dotnet/efcore#31751](https://github.com/dotnet/efcore/issues/31751)), and WebAssembly has no
-threads — reading `Instance` throws `TypeInitializationException` wrapping
+threads, so reading `Instance` throws `TypeInitializationException` wrapping
 `PlatformNotSupportedException`, and the app never renders.
 
 EF's own escape hatch makes it initialize inline, and it works:
@@ -54,7 +54,7 @@ AppContext.SetSwitch("Microsoft.EntityFrameworkCore.Issue31751", true);
 ```
 
 There is a second, better reason to skip it. `dotnet ef dbcontext optimize` needs a startup project
-it can load, and a Blazor WebAssembly project emits no `deps.json` — so your **server** ends up being
+it can load, and a Blazor WebAssembly project emits no `deps.json`, so your **server** ends up being
 the startup project, and EF's tooling then takes its configuration from the *server's* service
 provider, silently ignoring an `IDesignTimeDbContextFactory` in the client project.
 
@@ -64,7 +64,7 @@ dangerous shape: a model divergence between the two halves produces wrong answer
 errors.
 
 **Build the model at start-up instead**, as the sample does. If you do use a compiled model, verify
-which context it was generated from before trusting it — a one-line annotation like
+which context it was generated from before trusting it. A one-line annotation like
 `Relational:TableName` on a client model is the tell.
 
 ## Trimming
@@ -77,7 +77,7 @@ It reports IL trim warnings attributable to `InfoCarrier.Core`, and that is expe
 clean bill of health. The wire carries a type's **name** and the far end resolves it, so
 `Assembly.GetType(string)` and `MakeGenericMethod` are what this provider is made of, and
 `[DynamicallyAccessedMembers]` cannot describe "whatever type the caller's model names". The
-warnings mean the trimmer cannot *prove* the reflection safe for an arbitrary model — not that it
+warnings mean the trimmer cannot *prove* the reflection safe for an arbitrary model, and not that it
 broke yours.
 
 If you publish trimmed, test the paths your model actually uses. The repository gates the direction
@@ -132,4 +132,4 @@ private async ValueTask<GridItemsProviderResult<CustomerRow>> LoadAsync(
 ```
 
 And **order on the `IQueryable` before `Skip`/`Take`**, not through the grid's own sorting of the
-projected row — otherwise the server pages an unordered set and the client sorts the page.
+projected row. Otherwise the server pages an unordered set and the client sorts the page.

--- a/website/docs/security.md
+++ b/website/docs/security.md
@@ -1,8 +1,8 @@
 # Security
 
-Your server executes an expression tree that arrived over the network. That is the product, and it
-is the thing to think about before deploying it. This page covers what the library does about it and
-what it leaves to you.
+Your server executes an expression tree that arrived over the network. That is what the library is
+for, and it is the thing to think about before deploying it. This page covers what the library
+bounds and what it leaves to you.
 
 ## What the library bounds
 
@@ -69,8 +69,8 @@ everything a client submits is replayed through it.
 
 ## Think about the shape of the exposure
 
-A client can compose any query over the entity types your shared model exposes. That is the feature.
-It also means four things.
+A client can compose any query over the entity types your shared model exposes. That is what you
+asked for, and it has four consequences.
 
 The shared model is your API surface. An entity type in the shared project is a type any client can
 query, so if some data should never leave the server, keep it out of the shared model or map it on a

--- a/website/docs/security.md
+++ b/website/docs/security.md
@@ -1,35 +1,35 @@
 # Security
 
-**Your server executes an expression tree that arrived over the network.** That is the product, and
-it is the thing to think about before deploying it. This page is what the library does about it and
+Your server executes an expression tree that arrived over the network. That is the product, and it
+is the thing to think about before deploying it. This page covers what the library does about it and
 what it leaves to you.
 
 ## What the library bounds
 
-**Deserialization is default-deny.** The node kinds a payload may contain, the types it may name and
-the methods it may call are each checked against an allowlist. Anything not on it is refused rather
-than resolved.
+Deserialization is default-deny. The node kinds a payload may contain, the types it may name and the
+methods it may call are each checked against an allowlist. Anything not on it is refused rather than
+resolved.
 
-**No assembly is loaded to satisfy a payload.** A type name that does not resolve within what the
-server already has loaded is a refusal, not a load.
+No assembly is loaded to satisfy a payload. A type name that does not resolve within what the server
+already has loaded is refused.
 
-**Reflection entry points are blocked.** The allowlist deliberately excludes the members that would
-turn a resolved `Type` back into a call — the classic route from "a tree can name a type" to "a tree
-can invoke anything".
+Reflection entry points are blocked. The allowlist deliberately excludes the members that would turn
+a resolved `Type` back into a call, which is the route from "a tree can name a type" to "a tree can
+invoke anything".
 
-**There is a size bound**, applied before parsing begins, defaulting to 64 MiB on requests towards
-the server. A flat array of a hundred million constants is only three levels deep, so a depth limit
+There is a size bound, applied before parsing begins, defaulting to 64 MiB on requests towards the
+server. A flat array of a hundred million constants is only three levels deep, so a depth limit
 alone does not bound the memory a parse costs. See
 [server configuration](configuration/server.md#payload-limits).
 
-**A client cannot reach past the server's model.** The query is executed against the server's
+A client cannot reach past the server's model. The query is executed against the server's
 `DbContext`, with the server's model, its global query filters and its interceptors.
 
 ## What is yours
 
 !!! danger "Authentication and authorization are out of scope"
 
-    **No identity travels in the envelope.** The library has no concept of a user, a role or a
+    No identity travels in the envelope. The library has no concept of a user, a role or a
     permission, and it will happily execute a query for anyone who can reach the endpoint.
 
 Two things to do, and they are not optional:
@@ -43,7 +43,7 @@ app.MapInfoCarrier()
    .RequireAuthorization("DataAccess");
 ```
 
-On the client, authenticate the `HttpClient` — a bearer-token handler, a client certificate,
+On the client, authenticate the `HttpClient` with a bearer-token handler, a client certificate, or
 whatever your infrastructure uses. See
 [client configuration](configuration/client.md#the-http-transport).
 
@@ -61,7 +61,8 @@ protected override void OnModelCreating(ModelBuilder modelBuilder)
 ```
 
 This is the right place for row-level authorization. A filter declared only on the client's model is
-a convenience and not a boundary — the client is code you shipped to someone else's machine.
+a convenience rather than a boundary, because the client is code you shipped to someone else's
+machine.
 
 For writes, the server's `SaveChanges` override or an EF interceptor is the equivalent place:
 everything a client submits is replayed through it.
@@ -69,18 +70,21 @@ everything a client submits is replayed through it.
 ## Think about the shape of the exposure
 
 A client can compose any query over the entity types your shared model exposes. That is the feature.
-It also means:
+It also means four things.
 
-- **The shared model is your API surface.** An entity type in the shared project is a type any client
-  can query. If some data should never leave the server, keep it out of the shared model, or map it
-  on a server-only context.
-- **Expensive queries are reachable.** A caller can ask for a cross join. Bound it: query filters,
-  a paging convention, a per-caller rate limit at the gateway, a statement timeout on the database.
-- **Exception messages travel.** A server-side failure comes back with its message and its stack
-  trace. If your messages carry connection strings, file paths or internal identifiers, that is now
-  visible to the client — review them, and prefer catching and rewriting at the server boundary.
-- **Do not expose the endpoint to the public internet without authentication.** It is not a
-  read-only API; `SaveChanges` and `ExecuteDelete` are part of the same endpoint.
+The shared model is your API surface. An entity type in the shared project is a type any client can
+query, so if some data should never leave the server, keep it out of the shared model or map it on a
+server-only context.
+
+Expensive queries are reachable. A caller can ask for a cross join. Bound it with query filters, a
+paging convention, a per-caller rate limit at the gateway, or a statement timeout on the database.
+
+Exception messages travel. A server-side failure comes back with its message and its stack trace. If
+your messages carry connection strings, file paths or internal identifiers, that is now visible to
+the client. Review them, and prefer catching and rewriting at the server boundary.
+
+Do not expose the endpoint to the public internet without authentication. It is not a read-only API:
+`SaveChanges` and `ExecuteDelete` are part of the same endpoint.
 
 ## Transport security
 
@@ -90,6 +94,6 @@ own.
 
 ## Reporting a vulnerability
 
-Open an issue at [github.com/azabluda/InfoCarrier.Core](https://github.com/azabluda/InfoCarrier.Core)
-— or, for anything you would rather not disclose publicly, contact the maintainer through the
-repository before filing.
+Open an issue at
+[github.com/azabluda/InfoCarrier.Core](https://github.com/azabluda/InfoCarrier.Core). For anything
+you would rather not disclose publicly, contact the maintainer through the repository before filing.


### PR DESCRIPTION
The README and `CONTRIBUTING.md` (N26) are already on `main`. This applies the principles they settled to everything else a user reads: `docs/nuget-readme.md`, `samples/README.md`, `docs/limitations.md`, and all seventeen pages under `website/docs/`.

**22 files, +403 −328.** Two commits, and the second one corrects the first.

## The principles, from N26

Measured against twelve well-known .NET repositories rather than chosen by taste. Of the twelve, **zero mention a test count, zero have a Security section, zero have an architecture section**, and every one puts the documentation link near the top without explaining what is behind it.

1. Docs link in the first ten lines, one line, no explanation.
2. One example, not four.
3. No test counts, no security essay. Link instead.
4. Bullets for things that are genuinely a list; prose for things that are genuinely an argument.
5. Cut content, do not merely reword it.

## N27 — the mechanical pass

Em dashes in prose **190 → 0**, bold-label bullet lists **20 → 0**, counted outside fenced code blocks because a comment inside a sample is the sample's text and not this repository's prose.

Four pages were rewritten rather than edited: `website/docs/index.md` (four bold-label bullets and a verbatim test-count block), `website/docs/security.md` (twelve bold spans and a four-item bold list padding four real warnings), `website/docs/configuration/server.md` (five consecutive paragraphs opening with a bold API name and a dash), and `docs/nuget-readme.md`.

The other seventeen were edited line by line, so only sentences carrying a tell changed and the rest of each file is byte-identical.

**This could not have been a regex.** A blind substitution over `—` produces grammatical rubbish; the right replacement is a comma, colon, semicolon, full stop or a rewritten clause depending on what the sentence is doing, and about a third needed the clause rewritten.

## N28 — the correction, and it is the point of the PR

N27 claimed to give every document "the same treatment" as N26. It applied **two of the humanizer skill's thirty-five sections** and left the structural principles untouched:

| N26 principle | applied in N27 |
|---|---|
| Docs link in the first ten lines | no |
| No test counts | 2 files of 21 |
| No security essay, link instead | no |
| One example, not four | no |
| Cut content rather than reword it | **no** |

**`docs/nuget-readme.md` was the proof.** It kept a *Two packages* table, a *Status* section, a *Security* section and a full upgrade table, every one of which the README had dropped, so the two documents described the same product with opposite structures.

It is now the same shape as the README: the same four sections in the same order, the same three snippets under *Getting started*, **131 lines each**. The extra words are the two callouts that only matter on nuget.org, which is where a `3.1.1` user actually lands. Every link is absolute, because nuget.org cannot resolve a relative path.

**And a phrase removed from the README for being this exact pattern survived in `samples/README.md`**: *"sharing the type makes that true by construction rather than by discipline"*. That is what a mechanical pass looks like from the outside. The tell is fixed where you looked and untouched everywhere else.

### What deliberately stays

*"in the model rather than in the CLR type"*, *"refused rather than resolved"*, *"a class rather than a dictionary"*, *"wrong answers rather than errors"*.

A contrast between two concrete outcomes **is** the information, and the skill's own false-positive list says to keep real alternatives. What went is the rhetorical version, where the second half carries nothing: *"that is the product"*, *"that is the feature"*, *"it is removed rather than made almost right"*.

## Still to do, not in this PR

`samples/README.md` got the cosmetic pass but not the structural one. It is 243 lines of internal reasoning without a clear reader, and it needs the N26 treatment rather than another sweep for dashes.

## Gates

`mkdocs build --strict`, **exit 0, zero warnings**, after 17 site pages changed. **No `src/`, no `test/`.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
