### PR TITLE
Stop naming the v1 branches that are being deleted

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build & Test
 
 on:
   push:
-    # `main` is the only trunk. `master` and `develop` are v1 and carry their own (AppVeyor)
-    # build; a workflow that lives only on this branch cannot run on theirs anyway, so naming
-    # them here would be dead configuration.
+    # `main` is the only trunk. The v1 line lives on `release/3.1` and carries its own (AppVeyor)
+    # build; a workflow that lives only on this branch cannot run on that one anyway, so naming
+    # it here would be dead configuration.
     branches: [main]
   pull_request:
     branches: [main]

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ app.MapInfoCarrier();
 
 Built on [Entity Framework Core](https://github.com/dotnet/efcore) and judged by its test suite.
 
-[InfoCarrier.Core 1.0 to 3.1](https://github.com/azabluda/InfoCarrier.Core/tree/master), by
+[InfoCarrier.Core 1.0 to 3.1](https://github.com/azabluda/InfoCarrier.Core/tree/release/3.1), by
 [on/off it-solutions gmbh](http://www.onoff-it-solutions.info), proved the idea. It was inspired by
 [Remote.Linq](https://github.com/6bee/Remote.Linq) and
 [aqua-core](https://github.com/6bee/aqua-core) by Christof Senn, and built on them: they carried the

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -4,7 +4,7 @@
 
 ### `build.yml` — Build & Test
 
-Trigger: `push` to `main`/`develop`, `pull_request` to `main`.
+Trigger: `push` to `main`, `pull_request` to `main`.
 
 Runs on `ubuntu-latest` only — no Windows matrix needed. SQL Server is provided
 via a Docker service container, which works identically on Ubuntu.
@@ -13,7 +13,7 @@ via a Docker service container, which works identically on Ubuntu.
 name: Build & Test
 on:
   push:
-    branches: [main, develop]
+    branches: [main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
`master` and `develop` are going away. `develop` is **already gone** from the remote; `master` is still there.

`master`, `develop` and `release/3.1` are all the same commit (`9e7831a`), so **`release/3.1` carries the v1 line without losing anything** — the substitution needed no judgement call.

## Three live references

| File | Was | Now |
|---|---|---|
| `README.md` | credits link to `tree/master` | `tree/release/3.1`, verified **200** |
| `.github/workflows/build.yml` | a comment explaining why the v1 branches are not listed as triggers, naming two branches that will not exist | names `release/3.1` |
| `docs/ci-cd.md` | "Trigger: `push` to `main`/`develop`" plus `branches: [main, develop]` in its embedded YAML | `main` only |

`docs/ci-cd.md` was stale on two counts: the workflow has triggered on `main` alone since Phase N, so its prose *and* its example YAML both disagreed with the file they describe.

## Left alone on purpose

`docs/archive/` and `docs/implementation-plan.md` still say `master` and `develop` in a dozen places. Those are records of what was done at the time, and rewriting them would falsify the record rather than update it.

The other `master` hits are **master-detail** screens in the samples documentation.

## One consequence worth knowing before you delete it

Deleting `master` breaks any inbound link pointing at `.../tree/master`, and the published `InfoCarrier.Core 3.1.1` listing on nuget.org cannot be edited. `release/3.1` preserves the content, not the URL.

**Gates: none.** No `src/`, no `test/`, and no site page changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)