### PR TITLE
Enforce the licence header on .cs files (IDE0073)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -27,3 +27,33 @@ root = true
 # Disabling it would only have pre-empted every style rule anyone later wanted to adopt, silently.
 # ---------------------------------------------------------------------------------------------
 dotnet_diagnostic.IDE0005.severity = warning
+
+# ---------------------------------------------------------------------------------------------
+# IDE0073: file header.
+#
+# Every source file in this repository carries the same one-line licence notice. This makes that
+# a rule rather than a habit, and gives Visual Studio's *Fix All* something to apply, so a new
+# file gets the header without anyone remembering to paste it.
+#
+# `file_header_template` is the text WITHOUT the comment marker. The analyzer prepends `//`
+# itself; putting `//` in the template produces `// // Licensed...`.
+#
+# This is a build warning because `EnforceCodeStyleInBuild` is on, and warnings are errors when
+# `CI=true`. Every compiled file already complies, so turning it on changes no build today.
+# ---------------------------------------------------------------------------------------------
+file_header_template = Licensed under the MIT license. See license.txt file in the project root for license information.
+dotnet_diagnostic.IDE0073.severity = warning
+
+# ---------------------------------------------------------------------------------------------
+# EF's generated compiled-model baselines must NOT get the header.
+#
+# `CompiledModelInfoCarrierTest` compares the source EF generates against these files, so an
+# extra line at the top of one fails the test rather than tidying it. They are already
+# `<Compile Remove>`d in the test project, so the analyzer does not see them and this section is
+# inert today -- it is here so that un-excluding them does not quietly break the comparison.
+#
+# Regenerate them with `EF_TEST_REWRITE_BASELINES=1`, never by hand or by Fix All.
+# ---------------------------------------------------------------------------------------------
+[test/InfoCarrier.Core.FunctionalTests/InMemory/Scaffolding/Baselines/**.cs]
+file_header_template = unset
+dotnet_diagnostic.IDE0073.severity = none


### PR DESCRIPTION
Every source file already carries the same one-line MIT notice. This makes it a rule rather than a habit, so **Fix All** has something to apply and a new file cannot quietly ship without one.

```ini
file_header_template = Licensed under the MIT license. See license.txt file in the project root for license information.
dotnet_diagnostic.IDE0073.severity = warning
```

`file_header_template` is the text **without** the comment marker. The analyzer prepends `//` itself; putting `//` in the template produces `// // Licensed…`.

## It does not change any build today

`EnforceCodeStyleInBuild` is already on and `CI=true` turns warnings into errors, so this rule reaches CI immediately. Measured before committing:

```
Build succeeded.
    5 Warning(s)      <- the known IL2110/IL2111 from the Blazor sample
    0 Error(s)
```

All 241 compiled files already comply.

## Verified it can fail, not only that it passes

A rule that never fires looks exactly like one that works. A temporary header-less file in `src/`:

```
error IDE0073: A source file is missing a required header.
Build FAILED.
```

The probe file was then removed.

## EF's baselines are excluded, and this is the part worth reading

42 `.cs` files under `test/…/Scaffolding/Baselines/` have no header **on purpose**. `CompiledModelInfoCarrierTest` compares the source EF generates against those files, so an extra line at the top fails the test rather than tidying it.

They are already `<Compile Remove>`d, so the analyzer never sees them and the exclusion section is inert today. It is there so that un-excluding them later does not silently break the comparison. **Regenerate them with `EF_TEST_REWRITE_BASELINES=1`, never by hand and never with Fix All.**

## Gates

`CI=true dotnet build --configuration Release`: 0 errors. No behavioural change, so no `eng/measure.sh`; no sample change, so no trim ratchet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)