### PR TITLE
Move the milestone plans to docs/plans/v10/

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,7 +163,7 @@ jobs:
   # reasoning with was a key on somebody's laptop and a step nobody could repeat. A protected
   # ENVIRONMENT keeps the decision and drops the price: the job below does not start until a
   # required reviewer approves it, the key is an environment secret rather than a personal one,
-  # and every push is recorded against the run that made it. Dated note in docs/roadmap.md.
+  # and every push is recorded against the run that made it. Dated note in docs/plans/v10/roadmap.md.
   #
   # ONE-TIME SETUP, in two halves. BOTH ARE REQUIRED and each fails closed on its own.
   #

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,8 +128,8 @@ here, and both are cheap to avoid:
 |---|---|
 | `docs/decisions.md` | **ADR log.** LOCKED entries are binding. |
 | `docs/infocarrier-core-requirements.md` | Authoritative requirements spec |
-| `docs/roadmap.md` | **Stable** milestone plan for the whole project |
-| `docs/implementation-plan.md` | **Rolling** checkbox detail for the *current* milestone only |
+| `docs/plans/v10/roadmap.md` | **Stable** milestone plan for the whole project |
+| `docs/plans/v10/implementation-plan.md` | **Rolling** checkbox detail for the *current* milestone only |
 | `docs/architecture.md` | Components, test strategy, open questions |
 | `docs/research-findings.md` | EF Core 10 pipeline findings backing the ADRs |
 | `docs/decisions.md` **ADR-013** | The test project may reference `EFCore.Relational.Specification.Tests`. **Before adopting a relational spec base, check whether it assumes the *client* is relational** — a non-virtual `UseTransaction` calling `GetDbTransaction()` makes a base unreachable here, and cost 142 tests to discover. |
@@ -139,7 +139,7 @@ here, and both are cheap to avoid:
 **Roadmap vs plan — do not mix them.** Milestone-level scope, ordering, and exit criteria go
 in `roadmap.md`, which changes only when scope changes. Per-task checkboxes go in
 `implementation-plan.md`, which is rewritten at each milestone boundary (previous ones land in
-`docs/archive/`, never edited again). Putting task detail in the roadmap, or scope changes in
+`docs/plans/v10/archive/`, never edited again). Putting task detail in the roadmap, or scope changes in
 the plan, is what caused the drift these two docs replaced.
 
 **Reversing a LOCKED ADR requires a dated supersession edit in `docs/decisions.md`** — not a
@@ -157,10 +157,10 @@ Edits there are invisible to git and will be lost.
 **Never `[Skip]`, delete, or override a spec test to make the suite green.** The inherited
 `EFCore.Specification.Tests` classes *are* the coverage goal (ADR-004); a red test is
 information. If a test targets genuinely unimplemented functionality, leave it failing and
-note it in `docs/implementation-plan.md`. Silently suppressing tests was v1's stated failure
+note it in `docs/plans/v10/implementation-plan.md`. Silently suppressing tests was v1's stated failure
 mode.
 
-**Update the plan checkbox in the same commit as the work.** `docs/implementation-plan.md`
+**Update the plan checkbox in the same commit as the work.** `docs/plans/v10/implementation-plan.md`
 drifted out of sync with git once already (F1–F7 were committed while still shown unchecked).
 One substep per commit, message prefixed `Step <id>:`.
 
@@ -196,8 +196,8 @@ seam (so `InfoCarrier.Core` no longer references `EFCore.Relational`), the test 
 by backend store, four bases moved to the tier that translates, and the capability axis
 *identified, decided and recorded* rather than built (`architecture.md` §6a **D5**, answer (c);
 the original wording required a second backend, which M9 excluded). Task detail is archived at
-`docs/archive/implementation-plan-m9-phase-j.md` and is never edited again;
-`docs/implementation-plan.md` holds M8's Phases H and I only.
+`docs/plans/v10/archive/implementation-plan-m9-phase-j.md` and is never edited again;
+`docs/plans/v10/implementation-plan.md` holds M8's Phases H and I only.
 **The nine remaining failures now have a consumer-facing statement — `docs/limitations.md`** — and
 that is the document to keep true, because it is the only one written for someone outside this
 repository. It says one unsupported scenario, one query to treat with caution, two message-text
@@ -229,7 +229,7 @@ Northwind query bases and `GraphUpdatesTestBase`, `PropertyValuesTestBase`, `Fin
 `CompositeKeyEndToEnd`, `NotificationEntities`, `FieldsOnlyLoad`,
 `OverzealousInitialization`, `FieldMapping`, `Load`, `Updates`, `WithConstructors`,
 `ComplexTypeQuery`, `Spatial` and both `ManyToMany*Load` bases are clear.
-**Every failure is classified — A54 in `docs/implementation-plan.md` for the 44 that predate A59,
+**Every failure is classified — A54 in `docs/plans/v10/implementation-plan.md` for the 44 that predate A59,
 the A59/A61/A62/A63/A65 tables for the 75 those batches added, Phase B's B3a–B16 for what the
 Tier B adoptions added, and Phase C's C1–C96 for the rest — **C96 re-derives the whole tail**, and
 **Phase J's "The residual 13, examined properly" re-derives it again against M9's run** — read out of `artifacts/measure/`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,6 @@ One logical change per commit. Say what changed and why it was worth changing. T
 | [`docs/wire-protocol.md`](docs/wire-protocol.md) | Client and server contract |
 | [`docs/expression-serialization.md`](docs/expression-serialization.md) | How a LINQ tree becomes bytes |
 | [`docs/projection-split.md`](docs/projection-split.md) | What runs on the server, what runs on the client |
-| [`docs/roadmap.md`](docs/roadmap.md) | Milestones and CI strategy |
+| [`docs/plans/v10/roadmap.md`](docs/plans/v10/roadmap.md) | Milestones and CI strategy |
 | [`docs/build-warnings.md`](docs/build-warnings.md) | Which warnings are fatal, which are suppressed, where, and why |
 | [`docs/versioning.md`](docs/versioning.md) | How a version is decided, and how to cut a release |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -467,7 +467,7 @@ is explicitly out of M9's scope.
 **Consequence for M9's exit criterion, stated so the closure is not a fudge.** The criterion was
 written as *"a query boundary that also asks what the backend can evaluate"*. Taken literally it
 cannot be met inside M9: there is no second backend to ask, and adding one is the thing M9 puts out
-of scope. It is restated in [`roadmap.md`](roadmap.md) as *"the axis is identified, decided and
+of scope. It is restated in [`roadmap.md`](plans/v10/roadmap.md) as *"the axis is identified, decided and
 recorded"*, which is what was actually achievable and what has been done.
 
 **What would reopen this:** adopting a second store. At that point (c) needs a concrete shape — one

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -5,7 +5,7 @@ and rationale.
 
 > **Status note.** The pre-implementation research phase closed 2026-07-22
 > ([`research-findings.md`](research-findings.md)); the project is now in **implementation**
-> (see [`roadmap.md`](roadmap.md)). Each entry is marked:
+> (see [`roadmap.md`](plans/v10/roadmap.md)). Each entry is marked:
 > - **LOCKED** — decided and binding; reversing requires a dated supersession edit here.
 > - **PROVISIONAL** — current best understanding, **subject to change** as research
 >   continues. Provisional entries shape the specs but are not yet commitments; each links
@@ -158,7 +158,7 @@ identically. See [`research-infrastructure.md`](research-infrastructure.md).
 > **Record note.** [`research-findings.md`](research-findings.md) §"Locked consequences"
 > declared this ADR locked on 2026-07-22, and
 > [`expression-serialization.md`](expression-serialization.md) §3 +
-> [`implementation-plan.md`](implementation-plan.md) both cite it — but the entry was never
+> [`implementation-plan.md`](plans/v10/implementation-plan.md) both cite it — but the entry was never
 > written into this log. Recorded here retroactively from those sources. No decision changed;
 > this closes a dangling reference.
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,0 +1,31 @@
+# Plans
+
+Working documents that belong to one generation of the provider: the roadmap, the rolling
+implementation plan, superseded plans, and feature-level design notes.
+
+`docs/` above this folder is the other kind of document. Architecture, the ADR log, the wire
+format, the security review and the requirements describe the provider itself. They are edited as
+it changes and they are never copied forward.
+
+## Where the next generation goes
+
+This provider's major version tracks Entity Framework Core's, so `v10` is the work that produced
+InfoCarrier.Core 10. When EF Core 11 arrives, add `docs/plans/v11/` beside it and leave `v10/`
+alone as the record of how 10 was built.
+
+Only plans are scoped this way. Do not create `docs/plans/v11/architecture.md`: architecture does
+not fork per EF major, it gets edited, and a copied file drifts from the one it was copied from.
+An ADR written during M4 still binds in v11, which is why `docs/decisions.md` stays where it is.
+
+## Inside a generation
+
+| | |
+|---|---|
+| `roadmap.md` | Milestone scope, ordering and exit criteria. Changes when scope changes. |
+| `implementation-plan.md` | Checkbox detail for the current milestone only. |
+| `archive/` | Plans for finished milestones, kept as the record and never edited again. |
+| `superpowers/` | Feature-level plans and specs produced while building something specific. |
+
+The split between the roadmap and the implementation plan is deliberate and predates this folder:
+milestone-level scope in one, per-task checkboxes in the other. Mixing them is what caused the
+drift those two documents were written to replace.

--- a/docs/plans/v10/archive/2026-07-query-pipeline-plan.md
+++ b/docs/plans/v10/archive/2026-07-query-pipeline-plan.md
@@ -6,8 +6,8 @@
 > [`../implementation-plan.md`](../implementation-plan.md) (current milestone detail).
 > Kept as the record of what was built and which commit built it. **Do not edit.**
 
-Build order per [ADR-003](../decisions.md) · Design per [ADR-006](../decisions.md) (raw
-capture), [ADR-008](../decisions.md), [`research-findings.md`](../research-findings.md).
+Build order per [ADR-003](../../../decisions.md) · Design per [ADR-006](../../../decisions.md) (raw
+capture), [ADR-008](../../../decisions.md), [`research-findings.md`](../../../research-findings.md).
 
 Each checkbox is one minimal, logically-complete substep, committed individually.
 Not every substep is independently compilable — the milestone is the commit boundary.

--- a/docs/plans/v10/archive/2026-08-m1-query-correctness-plan.md
+++ b/docs/plans/v10/archive/2026-08-m1-query-correctness-plan.md
@@ -1,11 +1,11 @@
 # Implementation Plan — M1: Query pipeline correctness + working signal
 
-Status: **IN PROGRESS** · Milestone [M1](roadmap.md#m1--query-pipeline-correctness--working-signal)
+Status: **IN PROGRESS** · Milestone [M1](../roadmap.md#m1--query-pipeline-correctness--working-signal)
 
 **Scope of this doc:** the current milestone only. Rewritten when M1 closes; the completed
 query-pipeline plan is archived at
-[`archive/2026-07-query-pipeline-plan.md`](archive/2026-07-query-pipeline-plan.md).
-Milestone-level scope belongs in [`roadmap.md`](roadmap.md), not here.
+[`archive/2026-07-query-pipeline-plan.md`](2026-07-query-pipeline-plan.md).
+Milestone-level scope belongs in [`roadmap.md`](../roadmap.md), not here.
 
 Each checkbox is one minimal, logically-complete substep, committed individually with the
 checkbox ticked **in the same commit** (CLAUDE.md).
@@ -259,8 +259,8 @@ code (roadmap M2).
 
 - [x] **L1.** Type allowlist enforced (ADR-008 constraint 2). Restores the M2 signal:
       32 → 1,421 failures, ~1,305 of them the projection split. ✅ `731cca2`
-- [x] **M2-0.** M2 design session — [`projection-split.md`](projection-split.md) +
-      [ADR-010](decisions.md#adr-010); research-findings §8 corrected (boundary is computed on
+- [x] **M2-0.** M2 design session — [`projection-split.md`](../../../projection-split.md) +
+      [ADR-010](../../../decisions.md#adr-010); research-findings §8 corrected (boundary is computed on
       the client, and is a rewrite rather than a cut). ✅ `<this commit>`
 
 ## Phase K — the residual 42, classified

--- a/docs/plans/v10/archive/implementation-plan-m6-phase-c.md
+++ b/docs/plans/v10/archive/implementation-plan-m6-phase-c.md
@@ -1,15 +1,15 @@
 ﻿# Implementation Plan — M2: Projection split
 
-Status: **IN PROGRESS** · Milestone [M2](roadmap.md#m2--projection-split-requirements-3)
+Status: **IN PROGRESS** · Milestone [M2](../roadmap.md#m2--projection-split-requirements-3)
 
 **Scope of this doc:** the current milestone only. Milestone-level scope belongs in
-[`roadmap.md`](roadmap.md), not here. Design authority for this milestone is
-[`projection-split.md`](projection-split.md) ([ADR-010](decisions.md#adr-010)); read it before
+[`roadmap.md`](../roadmap.md), not here. Design authority for this milestone is
+[`projection-split.md`](../../../projection-split.md) ([ADR-010](../../../decisions.md#adr-010)); read it before
 touching any phase below.
 
-Previous plans: [`archive/2026-08-m1-query-correctness-plan.md`](archive/2026-08-m1-query-correctness-plan.md)
+Previous plans: [`archive/2026-08-m1-query-correctness-plan.md`](2026-08-m1-query-correctness-plan.md)
 (M1 — including the standing failure taxonomy and the Phase K classification of the residual 42),
-[`archive/2026-07-query-pipeline-plan.md`](archive/2026-07-query-pipeline-plan.md).
+[`archive/2026-07-query-pipeline-plan.md`](2026-07-query-pipeline-plan.md).
 Archived plans are never edited again.
 
 Each checkbox is one minimal, logically-complete substep, committed individually with the
@@ -47,7 +47,7 @@ The split with no projection rewrite: ship server-executable subtrees whole, run
 locally. Correct but coarse; A must never be *silently* wrong, which is what A4 is for.
 
 - [x] **A1.** `Query/WireTypeCollector` — the types a node would put on the wire
-      ([`projection-split.md`](projection-split.md) §3.1), enumerated from the same sources
+      ([`projection-split.md`](../../../projection-split.md) §3.1), enumerated from the same sources
       `ExpressionToNodeTranslator` writes `TypeNode`s from. The drift guard compares **per node**,
       not whole-tree: types repeat across a tree, so a whole-tree comparison passed even with
       `Member.DeclaringType` dropped. Six omissions mutation-tested, all caught. ✅ `<this commit>`
@@ -3018,7 +3018,7 @@ ships a test on, and where both exist the tier that *translates* is the one whos
 - [x] **C48. The security review — and the type allowlist's safety turns out to be a conjunction.**
       **`Total tests: 22347, Passed: 21987, Failed: 143, Skipped: 217`** (`c48`) — **143 → 143,
       0 fixed, 0 broken.** Total up 18 for the adversarial tests.
-      [`docs/security-review.md`](security-review.md). ✅ `<this commit>`
+      [`docs/security-review.md`](../../../security-review.md). ✅ `<this commit>`
 
       M5's last criterion. The review walks the ten stages from bytes to execution and says which
       control governs each; the useful part is what reading `TypeAllowlist` adversarially turned
@@ -7326,7 +7326,7 @@ failures are left red and classified rather than worked immediately.
       is ADR-008's constraint 2, the thing that stops a serialized tree from naming arbitrary
       types. SQLite and SQL Server translate `Regex.IsMatch` to SQL; the InMemory store runs it
       as .NET. **Whether this provider should allowlist it is a design decision for
-      `docs/roadmap.md`, not a fix**, and it is deliberately not made here.
+      `docs/plans/v10/roadmap.md`, not a fix**, and it is deliberately not made here.
 
 - [x] **A47.** The nine `ModelBuilding.ModelBuilderTest` bases.
       **`Total tests: 17136, Passed: 16952, Failed: 26, Skipped: 158`** — **703 tests added, every
@@ -8540,10 +8540,10 @@ has to preserve what each operator expects of its source, and a transparent iden
 
 ---
 
-## Phase X — transparent identifiers ([`transparent-identifiers.md`](transparent-identifiers.md), ADR-011)
+## Phase X — transparent identifiers ([`transparent-identifiers.md`](../../../transparent-identifiers.md), ADR-011)
 
 - [x] **X0.** Design session: read EF's `TryFlattenGroupJoinSelectMany` at source, wrote the
-      spec, recorded [ADR-011](decisions.md#adr-011). ✅ `db5dcdd`
+      spec, recorded [ADR-011](../../../decisions.md#adr-011). ✅ `db5dcdd`
 
 - [x] **X1.** Mirror `TryFlattenGroupJoinSelectMany` on the client, before the boundary analysis.
       **First attempt measured `111 → 111` and was reverted. The revert was a mistake** — see X6,
@@ -8744,7 +8744,7 @@ Small families with unrelated causes, taken one at a time. Each is measured on i
       *server's* context instance. The measured answer is 7 rows in every case, which is the
       server default `TenantPrefix = "B"`; the client's `"F"` never crosses the wire.
 
-      This is an architectural consequence of [ADR-006](decisions.md)'s capture point, not an
+      This is an architectural consequence of [ADR-006](../../../decisions.md)'s capture point, not an
       oversight, and it needs a decision rather than a patch. The options are for the client to
       apply filters itself before shipping (duplicating EF's filter machinery, which handles
       inheritance and navigations) or to ship filter parameter values with the request (which
@@ -8924,7 +8924,7 @@ that list is for bases *conceptually inapplicable* to a remoting provider, and C
 it for the spatial bases on the ground that "not built yet" does not qualify. The same refusal
 binds here. **So M6 is blocked on the B12 decision** (C21), not on available work.
 
-Then archive this doc as `docs/archive/2026-08-m6-coverage-expansion-plan.md` and rewrite it for
+Then archive this doc as `docs/plans/v10/archive/2026-08-m6-coverage-expansion-plan.md` and rewrite it for
 **M7 — SQL Server (Tier C)**, whose spatial half is already done and must not be re-planned
 (C15/C17/C18).
 

--- a/docs/plans/v10/archive/implementation-plan-m9-phase-j.md
+++ b/docs/plans/v10/archive/implementation-plan-m9-phase-j.md
@@ -6,7 +6,7 @@ milestone is [`../implementation-plan.md`](../implementation-plan.md).
 
 **Closed at `Total tests: 22658, Passed: 22472, Failed: 9, Skipped: 177`** (`j21`), from
 `13 / 22655` at the milestone's last pre-close measurement. Every one of the nine is classified
-below, and the consumer-facing statement of them is [`../limitations.md`](../limitations.md).
+below, and the consumer-facing statement of them is [`../limitations.md`](../../../limitations.md).
 
 ---
 
@@ -16,7 +16,7 @@ Scope lives in [`roadmap.md`](../roadmap.md) §M9. **M8 is not closed**, so this
 milestones at once for the first time; Phase J is appended rather than replacing Phases H and I,
 and the whole file is rewritten when M8 closes.
 
-The audit that opened this phase is in [`architecture.md`](../architecture.md) §6a, D3 (amended) and
+The audit that opened this phase is in [`architecture.md`](../../../architecture.md) §6a, D3 (amended) and
 D4 (new). Two things it established are worth restating here because they shape the order below:
 the package reference is a **symptom**, and the **fixed query-boundary allowlist** is the
 assumption nobody had recorded.
@@ -524,7 +524,7 @@ Measured one at a time, because a combined move cannot tell which base moved the
       exposure is a property of the wire protocol as it stands, and **this API widens nothing**.
       Binding a token to its creator stays worth doing and stays M8's item.
       What does need deciding is ownership: a joined transaction must not commit or roll back on
-      dispose. [`architecture.md`](../architecture.md) §6a **D6**.
+      dispose. [`architecture.md`](../../../architecture.md) §6a **D6**.
 
 ### J4 — the test project organised by backend store
 
@@ -888,7 +888,7 @@ should travel as its provider value**, the way `ChangeEntryMapper` already sends
 - [x] **J6. Ask the backend what it can evaluate — a second axis, beside the allowlist.**
       **DECIDED 2026-08-17: answer (c), no mechanism in M9.** The decision, its argument, and the
       table of coarse-versus-fine facts that is its actual deliverable are in
-      [`architecture.md`](../architecture.md) §6a **D5**; the exit criterion is restated in
+      [`architecture.md`](../../../architecture.md) §6a **D5**; the exit criterion is restated in
       [`roadmap.md`](../roadmap.md). Two things are worth repeating here because they are what decided
       it: **(b) cannot express J10** — a `ValueTuple` join key refused where an anonymous type and a
       `Tuple` are accepted is a property of the *tree shape*, and no provider manifest carries that
@@ -901,7 +901,7 @@ should travel as its provider value**, the way `ChangeEntryMapper` already sends
       conjunction. A backend must never widen it. The missing axis is separate and only ever
       **narrows** what is shipped: *can the thing at the other end evaluate this?*
       Four candidate answers, the difficulty of the automatic one, and why nothing is blocked on it
-      today are in [`architecture.md`](../architecture.md) §6a **D5**. **Design first, as D3 was.**
+      today are in [`architecture.md`](../../../architecture.md) §6a **D5**. **Design first, as D3 was.**
 
 ### Recorded, not scheduled
 
@@ -1128,7 +1128,7 @@ should travel as its provider value**, the way `ChangeEntryMapper` already sends
 - [x] **J20. `Regex` is admitted to `TypeAllowlist`, reversing A46.** `<this commit>`
       `Total tests: 22658, Passed: 22471, Failed: 10, Skipped: 177` (`j20` against `j19`):
       **2 fixed, 0 broken. 12 → 10.** `eng/trim-ratchet.sh`: `OURS: 88 <= 88`.
-      **The decision and its argument live in [`security-review.md`](../security-review.md) §4a**, which
+      **The decision and its argument live in [`security-review.md`](../../../security-review.md) §4a**, which
       is where a change to an ADR-008 control belongs; this entry records only what was measured.
 
       **A46 was a decision, not a finding, and it was never argued on the merits.** It recorded that

--- a/docs/plans/v10/implementation-plan.md
+++ b/docs/plans/v10/implementation-plan.md
@@ -15,12 +15,12 @@ by *removing* the newer one. Phase J is archived; Phases H and I below are M8's 
 
 The suite stands at `Total tests: 22658, Passed: 22472, Failed: 9, Skipped: 177` (`j21`). All nine
 are classified in the archived M9 plan, and stated for consumers in
-[`limitations.md`](limitations.md). None is a blocker for M8.
+[`limitations.md`](../../limitations.md). None is a blocker for M8.
 
 ## Phase H — the HTTP transport (spec: `superpowers/specs/2026-08-11-blazor-wasm-sample-design.md` §10 phase 1)
 
 Detailed steps are in
-[`superpowers/plans/2026-08-11-northwind-http-transport.md`](superpowers/plans/2026-08-11-northwind-http-transport.md).
+[`superpowers/plans/2026-08-11-northwind-http-transport.md`](superpowers/2026-08-11-northwind-http-transport.md).
 **That document is the "how"; this one is the record of what landed and what it measured.**
 
 - [x] **M8-1. The spec measurement is scoped to one project, and the M8 plan is open.** `<this commit>`
@@ -218,7 +218,7 @@ Recorded by M8-7 and M8-8 as findings rather than absorbed. Each names where it 
 ## Phase I — the browser (spec: `superpowers/specs/2026-08-11-blazor-wasm-sample-design.md` §10 phase 2)
 
 Detailed steps are in
-[`superpowers/plans/2026-08-16-northwind-blazor-wasm.md`](superpowers/plans/2026-08-16-northwind-blazor-wasm.md).
+[`superpowers/plans/2026-08-16-northwind-blazor-wasm.md`](superpowers/2026-08-16-northwind-blazor-wasm.md).
 **That document is the "how"; this one is the record of what landed and what it measured.**
 
 Phase 1 proved the wire, so a failure in this phase is a failure of the browser rather than of the
@@ -1154,7 +1154,7 @@ it, and a new warning now fails CI.
 ## Phase N — the documentation a consumer reads
 
 Two audiences, and the whole phase exists because they had been served by one set of files. The
-three READMEs are the *repository's* front doors; the site under [`../website/`](../website/) is
+three READMEs are the *repository's* front doors; the site under [`../website/`](../../../website/) is
 for a C# developer who has never seen this repository and does not want to. **Nothing internal
 goes on the site** — no ADR numbers, no phase labels, no test tiers, no wire internals beyond what
 a consumer must set.
@@ -1367,7 +1367,7 @@ rather than staying silent about it.
       | `docs/nuget-readme.md` | *Getting the packages* — a local feed over a downloaded `.nupkg` | *Installing* — the ordinary two lines |
       | `website/docs/getting-started/installation.md` | a **warning** admonition, then two workarounds | CLI / `PackageReference` / Package Manager tabs, with *from source* kept as an alternative |
       | `website/docs/index.md` | *"neither package is on nuget.org yet"* | the install line, preview caveat kept |
-      | `docs/roadmap.md` | *"Nothing has been published yet"* | published at `-preview.1`, and **why the suffix still stays** |
+      | `docs/plans/v10/roadmap.md` | *"Nothing has been published yet"* | published at `-preview.1`, and **why the suffix still stays** |
       | `docs/ci-cd.md` | *"`dotnet nuget push` to NuGet.org (needs `NUGET_API_KEY` secret)"* | what `release.yml` actually does |
 
       **`docs/ci-cd.md` was already wrong before this change, and only reading it to edit it found

--- a/docs/plans/v10/roadmap.md
+++ b/docs/plans/v10/roadmap.md
@@ -9,8 +9,8 @@ The fine-grained checkbox plan for the *current* milestone lives in
 [`implementation-plan.md`](implementation-plan.md), which is **rewritten each milestone**.
 Do not put per-milestone task detail here; do not put roadmap-level scope there.
 
-Authority: [`infocarrier-core-requirements.md`](infocarrier-core-requirements.md) ·
-[`decisions.md`](decisions.md) · [`research-findings.md`](research-findings.md)
+Authority: [`infocarrier-core-requirements.md`](../../infocarrier-core-requirements.md) ·
+[`decisions.md`](../../decisions.md) · [`research-findings.md`](../../research-findings.md)
 
 ---
 
@@ -55,7 +55,7 @@ Clear the mechanical failures masking the real state, and get a CI signal that c
 ### M2 — Projection split (requirements §3) ✅ **complete**
 
 The one genuinely unsolved design problem. **Spec written 2026-08-01:**
-[`projection-split.md`](projection-split.md), recorded as [ADR-010](decisions.md#adr-010).
+[`projection-split.md`](../../projection-split.md), recorded as [ADR-010](../../decisions.md#adr-010).
 
 Two things changed from the research-findings §8 sketch. The boundary is computed **on the
 client**, not the server — the allowlist rejects during deserialization, so the server never gets
@@ -104,18 +104,18 @@ minimal-column payload (W1).
 >   line in the right place took three attempts, costing 235 and then 69 tests respectively when
 >   drawn too widely.
 > - **Transparent identifiers are the remaining ceiling** — now specified in
->   [`transparent-identifiers.md`](transparent-identifiers.md) / [ADR-011](decisions.md#adr-011). `from … join … select new { a, b }`
+>   [`transparent-identifiers.md`](../../transparent-identifiers.md) / [ADR-011](../../decisions.md#adr-011). `from … join … select new { a, b }`
 >   makes an anonymous type EF handles internally and we must treat as a boundary, so everything
 >   downstream lands on the client. Deferring the reassembly and threading tuple slots through
 >   downstream operators is the next real gain, and is the "operator pushdown" the spec deferred.
 
 **Exit criteria**
-- **Result wire format** — spec written: [`result-wire-format.md`](result-wire-format.md).
+- **Result wire format** — spec written: [`result-wire-format.md`](../../result-wire-format.md).
   1,047 of 1,440 failures (73%). Do this first: it is independent of the type-boundary work,
   it unblocks SaveChanges, and until it lands most other failures are masked behind it.
 - ✅ Server-side type allowlist enforced, so client-only types cannot be materialized
   server-side even in-process. Projection tests fail again before they are fixed.
-- ✅ Design spec + ADR — [`projection-split.md`](projection-split.md), [ADR-010](decisions.md#adr-010).
+- ✅ Design spec + ADR — [`projection-split.md`](../../projection-split.md), [ADR-010](../../decisions.md#adr-010).
 - ✅ Boundary detection **in the client**; client applies the residual projection.
   `ServerQueryExecutor` unchanged, as the design's own test required.
 - ✅ Minimal-column payload (wire-protocol W1) — the same mechanism as the boundary rewrite, not
@@ -240,7 +240,7 @@ constraints it must meet when it lands.
   entries, so the client is given its own. Both were previously hidden by client and server
   sharing a process.
 - Security review of the deserialization path. ✅ (C48, 2026-08-10 —
-  [`security-review.md`](security-review.md).)
+  [`security-review.md`](../../security-review.md).)
 
   The material finding is that the type allowlist's safety is a **conjunction, not a single
   check**. `System.Type` is admitted and every enum is admitted, so a payload can legitimately
@@ -308,7 +308,7 @@ aborted the test host:
 | Piece | Plan | What it is |
 |---|---|---|
 | Type mapping | C15 | The NetTopologySuite branch every provider carries, in `InfoCarrierTypeMappingSource`. Worth 19 tests by itself: the client — not SpatiaLite — was what could not map a `Point`. |
-| Value-mapper seam | C17, [ADR-012](decisions.md#adr-012) | Product API. A geometry travels as one wire primitive instead of being walked reflectively, which is what overflowed the stack in C9. |
+| Value-mapper seam | C17, [ADR-012](../../decisions.md#adr-012) | Product API. A geometry travels as one wire primitive instead of being walked reflectively, which is what overflowed the stack in C9. |
 | WKT mapper | C18 | **Test-side**, so `InfoCarrier.Core` still does not reference NetTopologySuite — v1's arrangement, kept. |
 
 **Z and M survive because the format is WKT, not v1's GeoJSON**, which carries neither. That is
@@ -333,7 +333,7 @@ exceptions; it cannot cover a client that never runs again.
 still *read* correctly (isolation holds — it saw the pre-write value), but its **write blocked
 until the test's own timeout**. Once such a transaction has written, it holds SQLite's write lock,
 so one abandoned browser tab wedges writes for the whole server. Full detail in
-[`security-review.md`](security-review.md) §8.
+[`security-review.md`](../../security-review.md) §8.
 
 **DEPRIORITIZED 2026-08-16, and the reason is that the pattern it protects is not the recommended
 one.** Holding a store transaction open across client round trips is pessimistic locking over a
@@ -398,8 +398,8 @@ Three separable pieces, and only the first can be done outside the library:
   an environment secret rather than a personal one and every push is recorded against its run.
   Two further changes landed with it: **the version is now the git tag** (MinVer; there is no
   version number in any file, so the tag-versus-props check `release.yml` carried is gone — it was
-  also broken, see [`versioning.md`](versioning.md)), and **every code push publishes to GitHub
-  Packages** as an internal feed. Full account in [`versioning.md`](versioning.md).
+  also broken, see [`versioning.md`](../../versioning.md)), and **every code push publishes to GitHub
+  Packages** as an internal feed. Full account in [`versioning.md`](../../versioning.md).
 
 ### M9 — Provider neutrality and store coverage — **CLOSED 2026-08-17**
 
@@ -408,14 +408,14 @@ ran beside it, because its subject is orthogonal — M8 is about shipping the pr
 what the provider assumes of the store behind it.
 
 **All four exit criteria are met, one of them by restatement** (the capability axis; the reason is
-recorded with the criterion below and in [`architecture.md`](architecture.md) §6a D5). Task detail
+recorded with the criterion below and in [`architecture.md`](../../architecture.md) §6a D5). Task detail
 is archived at
 [`archive/implementation-plan-m9-phase-j.md`](archive/implementation-plan-m9-phase-j.md).
 
 **Closing state:** `Total tests: 22658, Passed: 22472, Failed: 9, Skipped: 177` — from
 `145 / 22312` when the ratchet was last refreshed, and `13 / 22655` at the start of the closing
 session. **Every one of the nine is classified**, and stated for consumers in
-[`limitations.md`](limitations.md) — the first time this project has had a limitations statement
+[`limitations.md`](../../limitations.md) — the first time this project has had a limitations statement
 aimed at someone outside it.
 
 **What it delivered beyond the criteria**, because the tier moves exposed real defects rather than
@@ -439,7 +439,7 @@ relational context (ADR-013). It nevertheless references `Microsoft.EntityFramew
 and its whole test suite runs on two stores, one of which is a real relational database. Nothing
 here is broken; the question is what would break under a store that is neither InMemory nor SQLite.
 
-**What the opening audit established** (evidence in [`architecture.md`](architecture.md) §6a D3):
+**What the opening audit established** (evidence in [`architecture.md`](../../architecture.md) §6a D3):
 
 - The package reference is used for **exactly one question** at four call sites, and is a symptom
   rather than the disease. `InfoCarrierTypeMappingSource`, `InfoCarrierValueGeneratorSelector`,
@@ -470,7 +470,7 @@ here is broken; the question is what would break under a store that is neither I
   **Decided: answer (c)** — one declaration, read by both halves, D2's shape — with **no mechanism
   built in M9**, because (b) cannot express a fact like J10's `ValueTuple` join key and because a
   mechanism should follow a second backend rather than precede it. The full decision, and the table
-  of coarse-versus-fine facts that is its deliverable, is [`architecture.md`](architecture.md)
+  of coarse-versus-fine facts that is its deliverable, is [`architecture.md`](../../architecture.md)
   §6a **D5**.
   **Why restated rather than met as written:** the original wording cannot be satisfied inside M9 —
   there is no second backend to ask, and adding one is explicitly out of this milestone's scope. A
@@ -501,7 +501,7 @@ here is broken; the question is what would break under a store that is neither I
 ## CI strategy
 
 Two jobs, because the spec suite is legitimately red during build-out and
-[`CLAUDE.md`](../CLAUDE.md) forbids skipping tests to force green.
+[`CLAUDE.md`](../../../CLAUDE.md) forbids skipping tests to force green.
 
 **Job 1 — fast gate (must be green).** Build + `ExpressionRoundTripTest` + `InMemorySmokeTest`.
 Any failure blocks.

--- a/docs/plans/v10/superpowers/2026-08-11-blazor-wasm-sample-design.md
+++ b/docs/plans/v10/superpowers/2026-08-11-blazor-wasm-sample-design.md
@@ -136,7 +136,7 @@ not reference.
 ### 3.3 Shared configuration is the point, not an implementation detail
 
 One shared `NorthwindContext` is the first worked example of a founding idea recorded as **D2** in
-[`architecture.md`](../../architecture.md) §6a: *one model configuration that both halves derive
+[`architecture.md`](../../../architecture.md) §6a: *one model configuration that both halves derive
 from and augment*.
 
 It is worth reading the sample as **evidence about D2's central expectation** — that the shared part
@@ -185,7 +185,7 @@ A reviewer should be able to check that by reading their `using` lines.
 
 ### 4.2 Open question carried, not answered — `Payload` is `byte[]`
 
-Recorded in full as **D1** in [`architecture.md`](../../architecture.md) §6a. Summary: the outer
+Recorded in full as **D1** in [`architecture.md`](../../../architecture.md) §6a. Summary: the outer
 envelope is JSON and `Payload` is `byte[]`, so the expression tree crosses as base64 — about 33%
 larger and unreadable.
 

--- a/docs/plans/v10/superpowers/2026-08-11-northwind-http-transport.md
+++ b/docs/plans/v10/superpowers/2026-08-11-northwind-http-transport.md
@@ -8,7 +8,7 @@
 
 **Tech Stack:** .NET 10, EF Core 10, ASP.NET Core minimal APIs, SQLite, xUnit, `Microsoft.AspNetCore.Mvc.Testing`.
 
-**Spec:** [`docs/superpowers/specs/2026-08-11-blazor-wasm-sample-design.md`](../specs/2026-08-11-blazor-wasm-sample-design.md). This plan implements its **Phase 1** only (spec §10). Phase 2 (Blazor WASM, Fluent UI, inspector, trimming) gets its own plan.
+**Spec:** [`docs/plans/v10/superpowers/2026-08-11-blazor-wasm-sample-design.md`](2026-08-11-blazor-wasm-sample-design.md). This plan implements its **Phase 1** only (spec §10). Phase 2 (Blazor WASM, Fluent UI, inspector, trimming) gets its own plan.
 
 ## Global Constraints
 
@@ -22,7 +22,7 @@ Every task's requirements implicitly include these.
 - **No NuGet dependency on Remote.Linq or Aqua** (ADR-001).
 - **EF1001 warnings are expected and allowed.** Do not suppress them repo-wide.
 - **The two transport files carry no sample types.** `HttpInfoCarrierTransport.cs` and `InfoCarrierEndpointExtensions.cs` must not mention Northwind, so that promoting them to packages later is a file move (spec §4.1). A reviewer checks this by reading their `using` lines.
-- **One task per commit.** Commit message prefixed `Step M8-<n>:`. Tick this plan's checkboxes and add the matching entry to `docs/implementation-plan.md` **in the same commit** — the repo has been bitten by those two drifting apart. **Stage this plan file as well as `implementation-plan.md`**; the per-task `git add` lines below name the source files and do not repeat these two.
+- **One task per commit.** Commit message prefixed `Step M8-<n>:`. Tick this plan's checkboxes and add the matching entry to `docs/plans/v10/implementation-plan.md` **in the same commit** — the repo has been bitten by those two drifting apart. **Stage this plan file as well as `implementation-plan.md`**; the per-task `git add` lines below name the source files and do not repeat these two.
 - **Do not run the full spec suite unless a task says to.** It takes 6–9 minutes. Only Tasks 1, 2 and 7 call for `eng/measure.sh`, and each states the exact expected output.
 - **Report test results as `Passed: N, Failed: M, Total: T` read from actual output.** Never estimate or infer a count.
 
@@ -33,7 +33,7 @@ Every task's requirements implicitly include these.
 | File | Responsibility |
 |---|---|
 | `eng/measure.sh` *(modify)* | Scope the spec measurement to one project. |
-| `docs/implementation-plan.md` *(replace)* | M8's rolling checkbox record; Phase C's is archived. |
+| `docs/plans/v10/implementation-plan.md` *(replace)* | M8's rolling checkbox record; Phase C's is archived. |
 | `samples/Northwind.Shared/Model/*.cs` | Five POCOs. No EF configuration, no behaviour. |
 | `samples/Northwind.Shared/NorthwindContext.cs` | The one shared context and its `OnModelCreating`. |
 | `samples/Northwind.Shared/NorthwindSeed.cs` | Deterministic seed data. |
@@ -61,12 +61,12 @@ Adding a second test project to the solution makes `dotnet test` emit two summar
 
 **Files:**
 - Modify: `eng/measure.sh:43`
-- Modify: `docs/implementation-plan.md` (replace with the M8 plan)
-- Create: `docs/archive/implementation-plan-m6-phase-c.md`
+- Modify: `docs/plans/v10/implementation-plan.md` (replace with the M8 plan)
+- Create: `docs/plans/v10/archive/implementation-plan-m6-phase-c.md`
 
 **Interfaces:**
 - Consumes: nothing.
-- Produces: a project-scoped `eng/measure.sh`; `docs/implementation-plan.md` with an M8 section whose entries later tasks tick.
+- Produces: a project-scoped `eng/measure.sh`; `docs/plans/v10/implementation-plan.md` with an M8 section whose entries later tasks tick.
 
 - [x] **Step 1: Record the current baseline number so the change can be proved neutral**
 
@@ -113,19 +113,19 @@ The REASONS diff must be empty. **If any line differs, stop.** The instrument ch
 - [x] **Step 4: Archive Phase C's plan and open M8's**
 
 ```bash
-git mv docs/implementation-plan.md docs/archive/implementation-plan-m6-phase-c.md
+git mv docs/plans/v10/implementation-plan.md docs/plans/v10/archive/implementation-plan-m6-phase-c.md
 ```
 
-Create a new `docs/implementation-plan.md`:
+Create a new `docs/plans/v10/implementation-plan.md`:
 
 ```markdown
 # Implementation plan — M8 (productization)
 
 Rolling checkbox detail for the **current** milestone only. M6's plan (Phases A–C) is in
-[`archive/implementation-plan-m6-phase-c.md`](archive/implementation-plan-m6-phase-c.md) and is
+[`archive/implementation-plan-m6-phase-c.md`](../archive/implementation-plan-m6-phase-c.md) and is
 never edited again.
 
-Milestone-level scope lives in [`roadmap.md`](roadmap.md). Do not put scope here.
+Milestone-level scope lives in [`roadmap.md`](../roadmap.md). Do not put scope here.
 
 The suite stands at `Total tests: 22453, Passed: 22219, Failed: 13, Skipped: 221` (`c96`). All 13
 are classified in C96 of the archived plan; none is a blocker for M8.
@@ -133,7 +133,7 @@ are classified in C96 of the archived plan; none is a blocker for M8.
 ## Phase H — the HTTP transport (spec: `superpowers/specs/2026-08-11-blazor-wasm-sample-design.md` §10 phase 1)
 
 Detailed steps are in
-[`superpowers/plans/2026-08-11-northwind-http-transport.md`](superpowers/plans/2026-08-11-northwind-http-transport.md).
+[`superpowers/plans/2026-08-11-northwind-http-transport.md`](2026-08-11-northwind-http-transport.md).
 **That document is the "how"; this one is the record of what landed and what it measured.**
 
 - [ ] **M8-1. The spec measurement is scoped to one project, and the M8 plan is open.** `<this commit>`
@@ -142,7 +142,7 @@ Detailed steps are in
 - [x] **Step 5: Commit**
 
 ```bash
-git add eng/measure.sh docs/implementation-plan.md docs/archive/implementation-plan-m6-phase-c.md
+git add eng/measure.sh docs/plans/v10/implementation-plan.md docs/plans/v10/archive/implementation-plan-m6-phase-c.md
 git commit -m "Step M8-1: scope the spec measurement to one project, and open the M8 plan
 
 eng/measure.sh ran dotnet test against the whole solution and parsed the LAST
@@ -153,7 +153,7 @@ FAILING: 13 TOTAL: 22453, with empty FIXED, BROKEN and REASONS diffs against c96
 
 eng/ratchet.sh needs no change -- CI has always run a single project.
 
-M6's plan is archived and docs/implementation-plan.md is reopened for M8."
+M6's plan is archived and docs/plans/v10/implementation-plan.md is reopened for M8."
 ```
 
 ---
@@ -555,7 +555,7 @@ Expected: `FAILING: 13  TOTAL: 22453`, with empty FIXED, BROKEN and REASONS diff
 - [x] **Step 11: Commit**
 
 ```bash
-git add samples/ test/InfoCarrier.Core.TransportTests/ InfoCarrier.Core.slnx Directory.Packages.props docs/implementation-plan.md
+git add samples/ test/InfoCarrier.Core.TransportTests/ InfoCarrier.Core.slnx Directory.Packages.props docs/plans/v10/implementation-plan.md
 git commit -m "Step M8-2: the shared Northwind model, and a test project of its own
 
 One NorthwindContext used by both halves, because the wire carries entity type
@@ -846,7 +846,7 @@ Expected: no `using` mentions `Northwind.Shared`, ASP.NET, or EF Core. Only `Sys
 - [x] **Step 9: Commit**
 
 ```bash
-git add samples/Northwind.Client.Transport/ test/InfoCarrier.Core.TransportTests/ InfoCarrier.Core.slnx docs/implementation-plan.md
+git add samples/Northwind.Client.Transport/ test/InfoCarrier.Core.TransportTests/ InfoCarrier.Core.slnx docs/plans/v10/implementation-plan.md
 git commit -m "Step M8-3: an IInfoCarrierTransport over HttpClient
 
 The transport seam is one method, so this is the whole client half. Tested
@@ -1180,7 +1180,7 @@ Expected: it starts, prints a listening URL, and creates `northwind.db` next to 
 - [x] **Step 11: Commit**
 
 ```bash
-git add samples/Northwind.Server/ test/InfoCarrier.Core.TransportTests/ InfoCarrier.Core.slnx Directory.Packages.props docs/implementation-plan.md
+git add samples/Northwind.Server/ test/InfoCarrier.Core.TransportTests/ InfoCarrier.Core.slnx Directory.Packages.props docs/plans/v10/implementation-plan.md
 git commit -m "Step M8-4: the server endpoint, and the first real HTTP hop in this repo
 
 One route, all nine operations. The product's InfoCarrierEnvelopeServer already
@@ -1348,7 +1348,7 @@ stale for the same reason. Not a discrepancy to fix by trimming the suite.
 - [x] **Step 4: Commit**
 
 ```bash
-git add test/InfoCarrier.Core.TransportTests/ docs/implementation-plan.md
+git add test/InfoCarrier.Core.TransportTests/ docs/plans/v10/implementation-plan.md
 git commit -m "Step M8-5: a DbContext with no database answers a query over real HTTP
 
 The premise of the product, asserted across a network boundary for the first
@@ -1521,7 +1521,7 @@ fix by trimming the suite.
 - [x] **Step 4: Commit**
 
 ```bash
-git add test/InfoCarrier.Core.TransportTests/ docs/implementation-plan.md
+git add test/InfoCarrier.Core.TransportTests/ docs/plans/v10/implementation-plan.md
 git commit -m "Step M8-6: SaveChanges and transactions over real HTTP
 
 Four tests: several edits crossing as one save (the unit-of-work shape), an
@@ -1559,8 +1559,8 @@ Passed: 16, Failed: 0, Total: 16."
 **Files:**
 - Modify: `.github/workflows/build.yml`
 - Modify: `CLAUDE.md`
-- Modify: `docs/roadmap.md`
-- Modify: `docs/implementation-plan.md`
+- Modify: `docs/plans/v10/roadmap.md`
+- Modify: `docs/plans/v10/implementation-plan.md`
 
 **Interfaces:**
 - Consumes: everything.
@@ -1581,14 +1581,14 @@ In `.github/workflows/build.yml`, in the `fast-gate` job, after the existing `Te
 
 - [x] **Step 2: Correct the two stale roadmap items**
 
-In `docs/roadmap.md`:
+In `docs/plans/v10/roadmap.md`:
 
 - Replace the `Measured 2026-08-10 (artifacts/measure/c54): Total tests: 22355, Passed: 22006, Failed: 132, Skipped: 217` paragraph and the sentence beginning `The 132 are classified` with the current figure: `Measured 2026-08-11 (artifacts/measure/c96): Total tests: 22453, Passed: 22219, Failed: 13, Skipped: 221. All 13 are classified in the archived plan's C96; ten are permanent by design or upstream.`
 - Delete the `**Known defects to fix in M1:** build.yml restores InfoCarrier.Core.sln …` paragraph in §CI strategy. It described the workflow before `51f4684`; C39 fixed it on 2026-08-10 and CI has been correct since.
 
 - [x] **Step 3: Record what Phase 1 did *not* close**
 
-Append to `docs/implementation-plan.md` under Phase H:
+Append to `docs/plans/v10/implementation-plan.md` under Phase H:
 
 ```markdown
 **Three things Phase 1 leaves open, stated so Phase 2 does not rediscover them.**
@@ -1640,7 +1640,7 @@ Expected: build succeeds; `Passed: 16, Failed: 0, Total: 16`; and `FAILING: 13  
 - [x] **Step 6: Commit**
 
 ```bash
-git add .github/workflows/build.yml CLAUDE.md docs/roadmap.md docs/implementation-plan.md
+git add .github/workflows/build.yml CLAUDE.md docs/plans/v10/roadmap.md docs/plans/v10/implementation-plan.md
 git commit -m "Step M8-7: wire the transport tests into CI, and record what Phase 1 left open
 
 The fast gate runs the new project as a second step. It stays out of the spec
@@ -1701,7 +1701,7 @@ Spec suite unchanged at 13/22453."
   unbounded body read (below the product's own `MaxRequestBytes`, so that limit is unreachable
   behind a default Kestrel host) — plus a note that §5's authn/authz exclusion was decided against
   an unreachable path and should be decided again now, not inherited. Both properties are also
-  recorded in `docs/implementation-plan.md`'s Phase H "leaves open" list. `CLAUDE.md`'s two
+  recorded in `docs/plans/v10/implementation-plan.md`'s Phase H "leaves open" list. `CLAUDE.md`'s two
   `dotnet test` commands, still pointed at `InfoCarrier.Core.slnx`, re-pointed at
   `test/InfoCarrier.Core.FunctionalTests/InfoCarrier.Core.FunctionalTests.csproj` — the scope
   `eng/measure.sh` already uses and for the same reason: the solution also contains

--- a/docs/plans/v10/superpowers/2026-08-16-northwind-blazor-wasm.md
+++ b/docs/plans/v10/superpowers/2026-08-16-northwind-blazor-wasm.md
@@ -5,7 +5,7 @@ saves a unit of work and runs a transaction against the Phase 1 server — in a 
 wire inspector showing every envelope, and publishing trimmed with no IL warning attributable to
 `InfoCarrier.Core`.
 
-**Spec:** [`../specs/2026-08-11-blazor-wasm-sample-design.md`](../specs/2026-08-11-blazor-wasm-sample-design.md).
+**Spec:** [`../specs/2026-08-11-blazor-wasm-sample-design.md`](2026-08-11-blazor-wasm-sample-design.md).
 This plan implements its **Phase 2** (spec §10); Phase 1 landed as M8-1 … M8-9.
 
 **Exit:** the spec's §9 success criteria, all five.
@@ -54,7 +54,7 @@ Every task's requirements implicitly include these.
   so promoting them is a file move (spec §4.1). The inspector must therefore be a **decorator**
   over `IInfoCarrierTransport` living in the client project — not a change to either file.
 - **One task per commit**, message prefixed `Step M8-<n>:`, with this plan's checkbox and the
-  matching `docs/implementation-plan.md` entry in the **same** commit.
+  matching `docs/plans/v10/implementation-plan.md` entry in the **same** commit.
 - **`eng/measure.sh` only where a task says so.** It costs 6–9 minutes. Only M8-11 and M8-16 touch
   anything the spec suite can see; the rest are `samples/` and cannot move it.
 - **Report test results as `Passed: N, Failed: M, Total: T`** read from actual output.
@@ -79,7 +79,7 @@ Every task's requirements implicitly include these.
 
 ### Task M8-10: Open this plan
 
-- [x] **Step 1:** Write this file and the Phase I section of `docs/implementation-plan.md`.
+- [x] **Step 1:** Write this file and the Phase I section of `docs/plans/v10/implementation-plan.md`.
 - [x] **Step 2:** Commit. No code, so no test run.
 
 ---
@@ -108,7 +108,7 @@ verification. A missing type cannot pass it.
       **Amended during the work:** the step as written said to carry over all three settings the
       old `Options` had, including `ReferenceHandler.Preserve`. That one **cannot** come along, and
       it turned out not to have been doing anything — see M8-11's entry in
-      `docs/implementation-plan.md`.
+      `docs/plans/v10/implementation-plan.md`.
 - [x] **Step 2:** Point `SystemTextJsonInfoCarrierSerializer` at `InfoCarrierJsonContext.Default.Options`.
 - [x] **Step 3:** Build; run `test/InfoCarrier.Core.TransportTests`.
 - [x] **Step 4:** `bash eng/measure.sh m8-11 c96`. **Expected: `FAILING: 13  TOTAL: 22453`, with
@@ -189,7 +189,7 @@ action.
       against the client's provider. The server is only the `--startup-project`, because a Blazor
       WASM project emits no `deps.json` and `dotnet ef` cannot load one.
 - [x] **Step 2:** Wire `UseModel` on the client; confirm the app still works. **It did not, at
-      first** — see the `Issue31751` finding in `docs/implementation-plan.md`.
+      first** — see the `Issue31751` finding in `docs/plans/v10/implementation-plan.md`.
 - [x] **Step 3:** `bash eng/measure.sh m8-16 m8-11` — expected unchanged.
 - [x] **Step 4:** Commit.
 
@@ -206,6 +206,6 @@ action.
       premise rather than an oversight; the honest annotation would be `[RequiresUnreferencedCode]`
       on the public query API, which is a product decision. Gated by `eng/trim-ratchet.sh`.
 - [x] **Step 4:** Add the publish to CI's fast gate.
-- [x] **Step 5:** Record what Phase 2 did **not** close, in `docs/implementation-plan.md`, with the
+- [x] **Step 5:** Record what Phase 2 did **not** close, in `docs/plans/v10/implementation-plan.md`, with the
       same candour Phase 1's M8-7 used.
 - [x] **Step 6:** Final measurement and commit.

--- a/docs/projection-split.md
+++ b/docs/projection-split.md
@@ -304,7 +304,7 @@ Each phase is a commit, and each must leave the suite **no worse** than the prev
   reaching the translation failure they assert. Each either returns to asserting its original
   failure or is deleted.
 
-## 9. Exit criteria (from [`roadmap.md`](roadmap.md) M2)
+## 9. Exit criteria (from [`roadmap.md`](plans/v10/roadmap.md) M2)
 
 - Boundary detection in the client; client applies the residual projection. *(relocated from the
   server per §2 — roadmap updated)*

--- a/docs/result-wire-format.md
+++ b/docs/result-wire-format.md
@@ -1,6 +1,6 @@
 # Result Wire Format — Design
 
-Status: **IMPLEMENTED (2026-08-01)** · Milestone [M2](roadmap.md) · Implements
+Status: **IMPLEMENTED (2026-08-01)** · Milestone [M2](plans/v10/roadmap.md) · Implements
 [`wire-protocol.md`](wire-protocol.md) §2.1 and [ADR-008](decisions.md) constraints 1 and 5.
 
 **Result: 1,109 → 3,692 passing of 4,247.** All three target error classes eliminated —

--- a/docs/security-review.md
+++ b/docs/security-review.md
@@ -240,7 +240,7 @@ correlation-id requirement should be revisited when one does.
 
 ## 8a. Amendment — the trigger fired
 
-Amended **2026-08-12**, as part of the M8-8 fix wave (`docs/implementation-plan.md`), because §8's
+Amended **2026-08-12**, as part of the M8-8 fix wave (`docs/plans/v10/implementation-plan.md`), because §8's
 own condition — "before a network transport ships" — has now been met: `test/InfoCarrier.Core.TransportTests`
 and the samples under `samples/` add a real HTTP transport, previously in-process only. This
 amendment records what changed character as a result. It recommends no fix; it records that two
@@ -273,5 +273,5 @@ should be made again, not inherited.
   network-reachability had already been weighed.
 
 No code change accompanies this amendment. Both properties are recorded in
-`docs/implementation-plan.md`'s Phase H "what Phase 1 leaves open" list alongside the three items
+`docs/plans/v10/implementation-plan.md`'s Phase H "what Phase 1 leaves open" list alongside the three items
 already there.

--- a/eng/trim-baseline.txt
+++ b/eng/trim-baseline.txt
@@ -1,11 +1,11 @@
 # Trim-warning ratchet baseline — see eng/trim-ratchet.sh and the M8-17 entry in
-# docs/implementation-plan.md.
+# docs/plans/v10/implementation-plan.md.
 #
 # `ours` counts UNIQUE IL2xxx diagnostics whose declaring member is an InfoCarrier.Core type, from
 # a `dotnet publish -c Release` of samples/Northwind.Client with PublishTrimmed=true.
 #
 # THE SPEC CRITERION IS NOT MET AND THIS FILE IS THE RECORD OF THAT. The Blazor sample design
-# (docs/superpowers/specs/2026-08-11-blazor-wasm-sample-design.md §9, criterion 4) asked for "no IL
+# (docs/plans/v10/superpowers/2026-08-11-blazor-wasm-sample-design.md §9, criterion 4) asked for "no IL
 # warning attributable to InfoCarrier.Core". There are 86. They are not sloppiness: the wire carries
 # a type's NAME and the far end resolves it, so `Assembly.GetType(string)`, `MakeGenericMethod`,
 # `MakeGenericType` and a reflective object walk are what this provider is made of.

--- a/test/InfoCarrier.Core.FunctionalTests/InMemory/Query/NorthwindQueryInfoCarrierTests.cs
+++ b/test/InfoCarrier.Core.FunctionalTests/InMemory/Query/NorthwindQueryInfoCarrierTests.cs
@@ -10,7 +10,7 @@ namespace InfoCarrier.Core.FunctionalTests.InMemory.Query;
 // EF Core's own NorthwindQuery*InMemoryTest classes.
 //
 // These start with NO overrides on purpose. Every failure is real information, triaged in
-// docs/implementation-plan.md into: conceptually inapplicable to a remoting provider, backing-
+// docs/plans/v10/implementation-plan.md into: conceptually inapplicable to a remoting provider, backing-
 // store limitation, or an InfoCarrier gap. Only the first two ever earn an override, and only
 // with a stated reason — never to make the suite green (CLAUDE.md).
 //
@@ -36,7 +36,7 @@ public class NorthwindFunctionsQueryInfoCarrierTest(NorthwindQueryInfoCarrierFix
     : NorthwindFunctionsQueryTestBase<NorthwindQueryInfoCarrierFixture<NoopModelCustomizer>>(fixture);
 
 // Classes that assert an InMemory store limitation live in their own files, each mirroring
-// EF Core's own *InMemoryTest override set. See docs/roadmap.md M3 for the inventory.
+// EF Core's own *InMemoryTest override set. See docs/plans/v10/roadmap.md M3 for the inventory.
 
 public class NorthwindNavigationsQueryInfoCarrierTest(NorthwindQueryInfoCarrierFixture<NoopModelCustomizer> fixture)
     : NorthwindNavigationsQueryTestBase<NorthwindQueryInfoCarrierFixture<NoopModelCustomizer>>(fixture)

--- a/test/InfoCarrier.Core.FunctionalTests/InfoCarrierComplianceTest.cs
+++ b/test/InfoCarrier.Core.FunctionalTests/InfoCarrierComplianceTest.cs
@@ -32,7 +32,7 @@ public class InfoCarrierComplianceTest : ComplianceTestBase
 
     /// <summary>
     ///     Bases that are conceptually inapplicable to InfoCarrier — each with the reason.
-    ///     Seeded in M1-I3; see docs/implementation-plan.md.
+    ///     Seeded in M1-I3; see docs/plans/v10/implementation-plan.md.
     /// </summary>
     protected override ICollection<Type> IgnoredTestBases { get; } = [];
 }

--- a/test/InfoCarrier.Core.FunctionalTests/Sqlite/Query/Associations/OwnedNavigationsQueryInfoCarrierTests.cs
+++ b/test/InfoCarrier.Core.FunctionalTests/Sqlite/Query/Associations/OwnedNavigationsQueryInfoCarrierTests.cs
@@ -125,7 +125,7 @@ public class OwnedNavigationsQueryInfoCarrierFixture : OwnedNavigationsFixtureBa
 }
 
 // The six OwnedNavigations facets (ADR-004), starting with no overrides. Every failure is real
-// information, triaged in docs/implementation-plan.md under C2.
+// information, triaged in docs/plans/v10/implementation-plan.md under C2.
 
 public class OwnedNavigationsCollectionQueryInfoCarrierTest(OwnedNavigationsQueryInfoCarrierFixture fixture)
     : OwnedNavigationsCollectionTestBase<OwnedNavigationsQueryInfoCarrierFixture>(fixture)

--- a/test/known-failures.txt
+++ b/test/known-failures.txt
@@ -22,7 +22,7 @@
 # 2026-08-10 (C39) — first refresh since the file was written, and it was eight months of Phase
 # A/B/C adoptions stale: 111/5215 against an actual 145/22312. CI would have failed on the
 # failure count while the total quadrupled. Every failure behind this number is classified —
-# Phase C's C1–C20 and the A/B tables in docs/implementation-plan.md.
+# Phase C's C1–C20 and the A/B tables in docs/plans/v10/implementation-plan.md.
 #
 # 2026-08-10 (C40) — 145 -> 144, the string-Include path validator. Lowered in the same commit
 # as the fix, which is what the header above asks for.
@@ -151,7 +151,7 @@
 # information and both are the wire's, not the store's: DynamicValueMapper.MapToNode takes its
 # collection branch on a key type that merely implements IEnumerable, and RehydrateObject cannot
 # construct a nested generic test type with no parameterless constructor. Both classified in J1 of
-# docs/implementation-plan.md. Figures read off the run's own summary block, never by arithmetic:
+# docs/plans/v10/implementation-plan.md. Figures read off the run's own summary block, never by arithmetic:
 # 22453 / 22224 / 15 / 214 (`j1b`).
 # 2026-08-16 (J2) - 15 -> 18, A DELIBERATE RISE, and `skipped` 214 -> 210. CustomConverters moved
 # from Tier A to Tier B. Its four skips were EF's own CustomConvertersInMemoryTest refusing issue
@@ -161,7 +161,7 @@
 # Optional_datetime_reading_null_from_database is no longer a silent no-op. The three that fail are
 # new information: an EF-internal GroupBy grouping type reaching the deserialization allowlist, an
 # untranslated Join over converted columns, and one A28-family test whose base asserts a limitation
-# this provider does not have. Classified in J2 of docs/implementation-plan.md.
+# this provider does not have. Classified in J2 of docs/plans/v10/implementation-plan.md.
 # Figures read off the run's own summary block: 22453 / 22225 / 18 / 210 (`j2b`).
 # 2026-08-16 (J4) - unchanged at 18/22453. The functional tests are organised by backend store now
 # (InMemory/ 57, Sqlite/ 25, TestUtilities/ 16, 18 store-independent). This file needed NO edit for


### PR DESCRIPTION
`docs/` held four things with four different lifecycles:

| Kind | Lines | Lifecycle |
|---|---|---|
| Durable reference (architecture, ADRs, wire format, security review, requirements) | ~2,450 | Edited forever, never forked |
| Contributor how-to (build-warnings, ci-cd, versioning) | ~520 | Edited forever |
| **Planning** (roadmap, implementation-plan, archive, superpowers) | **~16,000** | **Repeats per EF major** |
| Build inputs (`nuget-readme.md`, `assets/*.png`) | | Not documentation; packed into the `.nupkg` |

Only one of those repeats, and it was 80% of the bulk. **So planning moves and nothing else does.**

## The layout

```
docs/                 16 reference files, unchanged
docs/plans/
  README.md           where v11 goes, and what must not be version-scoped
  v10/
    roadmap.md
    implementation-plan.md
    archive/          4 superseded milestone plans
    superpowers/      3 feature-level plans and specs
```

Nested under `docs/` rather than a top-level `plans/`, because here the roadmap and the plan are **authority, not scratch**. `CLAUDE.md` lists both as binding, and "`docs/` is the source of truth" is a line the whole workflow leans on. Nesting still gets the bulk out of the way.

`docs/plans/README.md` records the rule that matters for next time: **do not create `docs/plans/v11/architecture.md`.** Architecture does not fork per EF major, it gets edited, and an ADR written during M4 still binds in v11.

## Mechanics

**47 references across 13 files** updated, including 8 in `CLAUDE.md`. Every one was prose or a comment. Nothing in the build resolves these paths, so this is a text change rather than a wiring change. The four `.cs` edits are comment text only.

Git recorded **all 9 moves as renames**, so history follows the files.

## Link checking found more than the move caused

A repo-wide check of relative links in tracked markdown now reports **0 broken**.

- **26 were broken by the move** and repaired.
- **17 were already broken before it** and were repaired too, mostly archived plans linking siblings as `roadmap.md` from inside `docs/archive/`, where that never resolved.

The archive is *"never edited again"* as a rule about the record, not about a path that stopped resolving.

## Gates

- `CI=true dotnet build --configuration Release`: **0 errors**, the same 5 known `IL2110`/`IL2111`.
- `mkdocs build --strict`: **exit 0, zero warnings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
