### PR TITLE
One switch for the trim report, and the analyzer that paid for nothing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,10 +58,12 @@ jobs:
           dotnet test test/InfoCarrier.Core.TransportTests/InfoCarrier.Core.TransportTests.csproj
           --no-build --configuration Release
 
-      # Phase 2 of M8. Publishes the Blazor client trimmed and gates on the DIRECTION of this
-      # product's IL2xxx count, not on zero — spec §9's "no warning attributable to
-      # InfoCarrier.Core" is not met and eng/trim-baseline.txt records why. The script publishes
-      # clean on purpose: an incremental publish does not re-run ILLink and would report zero.
+      # Phase 2 of M8. Publishes the Blazor client trimmed and gates on the DIRECTION of two
+      # IL2xxx counts, this product's and the sample's own, not on zero — spec §9's "no warning
+      # attributable to InfoCarrier.Core" is not met and eng/trim-baseline.txt records why. The
+      # script publishes clean on purpose: an incremental publish does not re-run ILLink and would
+      # report zero. It also turns the diagnostics on, with -p:TrimReport=true; no other build in
+      # this repository emits an IL2xxx at all.
       - name: Trim ratchet (Blazor publish)
         run: bash eng/trim-ratchet.sh
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,11 +72,12 @@ here, and both are cheap to avoid:
 
   **And the build itself is a gate now.** Warnings are errors when `CI=true`, so before any commit
   that touches code: `CI=true dotnet build InfoCarrier.Core.slnx --configuration Release`.
-  **`--configuration Release` is not optional and leaving it off is how CI went red for ten
-  commits without anyone noticing (N12).** The Blazor sample turns the trim analyzer on in Release
-  only, so the Debug build cannot produce the diagnostic that fails the server. It is seconds, it
-  is what the server runs, and a Debug build will not show you the failure. `docs/build-warnings.md` says what
-  is suppressed and why.
+  **`--configuration Release` is not optional**, because it is what the server builds, and a Debug
+  build has never been evidence about a Release one. Leaving it off is how CI went red for ten
+  commits without anyone noticing (N12): the Blazor sample ran the trim analyzer in Release only, so
+  Debug could not produce the diagnostic that was failing the server. **That particular trap is
+  closed** — N30 took the analyzer out of the ordinary build entirely — but the rule outlived its
+  reason and stands. `docs/build-warnings.md` says what is suppressed and why.
 - **A probe that prints nothing is evidence only once the build is known green — check the error
   count, never the elapsed time.** M9's J9 read three successive "nothing logged" results as
   clearances. All three were a **stale binary**: the probe named a property that does not exist

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,9 +45,9 @@ Read [`docs/build-warnings.md`](docs/build-warnings.md) before adding a `NoWarn`
 broken by name, and a diff of the failure *reasons*. Read the reasons. A count that did not move
 cannot tell "fixed four, broke four" apart from "changed nothing".
 
-`eng/trim-ratchet.sh` publishes the Blazor sample trimmed and compares its IL warnings against
-[`eng/trim-baseline.txt`](eng/trim-baseline.txt). It fails when the count goes up. The count does
-not have to be zero.
+`eng/trim-ratchet.sh` publishes the Blazor sample trimmed and compares two IL warning counts, the
+provider's and the sample's own, against [`eng/trim-baseline.txt`](eng/trim-baseline.txt). It fails
+when either goes up. Neither has to be zero.
 
 `eng/ratchet.sh` is the CI half of the same idea. The workflow invokes it, so you never have to.
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,10 +26,11 @@
       To reproduce a CI failure locally:
         CI=true dotnet build InfoCarrier.Core.slnx -c Release
 
-      THE CONFIGURATION IS PART OF THE COMMAND. Omitting it builds Debug, where the Blazor sample
-      does not run the trim analyzer, so the whole class of diagnostic that fails the server is
-      invisible. That omission kept the CI build red from M8-32 to N12 while a local `CI=true`
-      build reported `0 Warning(s), 0 Error(s)` every time.
+      THE CONFIGURATION IS PART OF THE COMMAND, because Release is what the server builds. Omitting
+      it once kept the CI build red from M8-32 to N12 while a local `CI=true` build reported
+      `0 Warning(s), 0 Error(s)` every time: the Blazor sample ran the trim analyzer in Release only,
+      so Debug could not produce the diagnostic that was failing. N30 removed that analyzer from the
+      ordinary build, so the specific trap is gone and the habit stays.
 
       `-c Release` rather than the long spelling, and that is not a style choice: a double hyphen
       cannot appear inside an XML comment. Writing the long form here made this file unparseable,
@@ -45,20 +46,6 @@
     -->
     <TreatWarningsAsErrors Condition="'$(CI)' == 'true'">true</TreatWarningsAsErrors>
 
-    <!--
-      ILLink's own warnings are never errors. The trimmed Blazor publish reports 88 IL2xxx
-      warnings owned by InfoCarrier.Core, unfixable by design: the wire carries a type's NAME, so
-      Assembly.GetType(string) and MakeGenericMethod are what this provider is made of, and
-      [DynamicallyAccessedMembers] cannot describe them. eng/trim-ratchet.sh gates their
-      DIRECTION against eng/trim-baseline.txt.
-
-      This property covers the ILLink TASK only. It is NOT what keeps the trim ratchet green, and
-      believing it was cost a run: most IL2xxx findings come from the trim ROSLYN ANALYZER during
-      compilation (they carry a source line), so plain TreatWarningsAsErrors turns those into
-      errors and this property never sees them. eng/trim-ratchet.sh therefore passes
-      -p:TreatWarningsAsErrors=false on its own publish, and says why.
-    -->
-    <ILLinkTreatWarningsAsErrors>false</ILLinkTreatWarningsAsErrors>
     <Company>InfoCarrier.Core</Company>
     <Product>InfoCarrier.Core</Product>
     <Description>Entity Framework Core database provider that remotes LINQ queries and change-tracking over a wire protocol.</Description>

--- a/docs/build-warnings.md
+++ b/docs/build-warnings.md
@@ -27,23 +27,50 @@ in, and a gate that punishes experimentation is a gate people switch off.
 CI=true dotnet build InfoCarrier.Core.slnx --configuration Release
 ```
 
-> **`--configuration Release` is part of the command, not decoration.** Omit it and you build
-> Debug, where `samples/Northwind.Client` does not run the trim analyzer — so an entire class of
-> diagnostic that fails the server cannot appear. That omission is exactly how the CI build stayed
-> red from M8-32 to N12 while a local `CI=true` build answered `0 Warning(s), 0 Error(s)` every
-> single time.
+> **`--configuration Release` is part of the command, not decoration**, because Release is what the
+> server builds. Omitting it is exactly how the CI build stayed red from M8-32 to N12 while a local
+> `CI=true` build answered `0 Warning(s), 0 Error(s)` every single time: `samples/Northwind.Client`
+> ran the trim analyzer in Release only, so Debug could not produce the diagnostic that was failing.
+> N30 removed that analyzer from the ordinary build, so that particular trap is closed. The rule
+> outlived its reason and stays.
 
 ## What is suppressed, where, and why
 
-There is **no repo-wide `NoWarn`**, and exactly **one** `WarningsNotAsErrors`, in one project
-file. Every suppression is scoped to the smallest place that makes sense.
+There is **no repo-wide `NoWarn`** and, since N30, **no `WarningsNotAsErrors` anywhere**. Every
+suppression is scoped to the smallest place that makes sense.
 
 | Code(s) | Where | Why |
 |---|---|---|
 | `EF1001` | file-scoped `#pragma warning disable EF1001` in the **19 files** that use EF Core internals | This provider is built on `IStateManager`, `EntityQueryable<>` and `InternalEntityEntry` by design. **This is what EF Core's own providers do** — `subrepos/efcore` has 51 such files across eight projects (21 in `EFCore.Relational`) and **no `NoWarn` for EF1001 anywhere**. Per file, so a **new** file reaching for an internal API still warns. |
 | `CS1591`, `CS1573`, `CS1574`, `CS1570` | `test/.editorconfig` and `samples/.editorconfig` | Nothing under `test/` or `samples/` is a public API surface anyone reads. Without this, the functional test project alone emits **1254** of them. In `src/` these stay **on**. |
-| `IL2xxx` | `-p:TreatWarningsAsErrors=false` on `eng/trim-ratchet.sh`'s own publish | The 88 trim warnings are unfixable by design and are gated by **direction**, not by zero. See below. |
-| `IL2110`, `IL2111` | `samples/Northwind.Client.csproj`, Release only | **Downgraded from error to warning, not silenced.** They come from the *framework's own* Razor output (`Router.NotFoundPage`, `LayoutView.Layout` in `App_razor.g.cs`) — not this repository's code, and not fixable here. `eng/trim-ratchet.sh` still counts them; `NoWarn` would make it count zero and pass for ever. Only these two codes: any other trim diagnostic still fails CI, which forces a look before a new one is tolerated. |
+
+
+## Trim warnings are not suppressed. They are switched on.
+
+`IL2xxx` is the one family that works the other way round, and it is worth reading as a separate
+mechanism rather than as a suppression.
+
+The Blazor SDK turns trim warnings off by default, so nothing in an ordinary build or publish
+reports them. `eng/trim-ratchet.sh` publishes with **`-p:TrimReport=true`**, which is the only
+place in the repository that sets it, and which turns on three properties declared together in one
+`PropertyGroup` in `samples/Northwind.Client.csproj`: `SuppressTrimAnalysisWarnings=false`,
+`TrimmerSingleWarn=false` and `TreatWarningsAsErrors=false`. The publish then reports every
+`IL2xxx` finding individually and the script gates two owners by direction against
+`eng/trim-baseline.txt`.
+
+**This used to be on for every Release build, and that cost two suppressions to survive `CI=true`:**
+a `WarningsNotAsErrors=IL2110;IL2111` in the sample's project file, and a
+`-p:TreatWarningsAsErrors=false` on the ratchet's own command line. Both are gone. So is
+`ILLinkTreatWarningsAsErrors` in `Directory.Build.props`, which was redundant once
+`TreatWarningsAsErrors` went false inside the switch: it defaults to `$(TreatWarningsAsErrors)`, and
+outside the switch ILLink emits nothing to promote.
+
+**Driven both ways, because a switch only seen in one position is not known to work.**
+`CI=true dotnet build InfoCarrier.Core.slnx -c Release --no-incremental` reports `0 Warning(s)`; the
+same command with `-p:TrimReport=true` reports `5 Warning(s)`, all `IL2110`/`IL2111`, and still
+exits 0 because the switch turns warnings-as-errors off along with them. `bash eng/trim-ratchet.sh`
+reports `ours OK (88 <= 88)` and `northwind OK (8 <= 8)`; run against a baseline saying
+`northwind=7` it exits **1**.
 
 ## Two traps, both of which cost a run
 
@@ -54,16 +81,33 @@ warning almost nobody reads — `EnableGenerateDocumentationFile`, which names t
 Those six projects now generate the file and switch the doc-comment rules off in a folder-scoped
 `.editorconfig` instead.
 
-**2. `ILLinkTreatWarningsAsErrors` does not do what its name suggests.** It feeds the ILLink
-*task*. Most `IL2xxx` findings come from the trim **Roslyn analyzer** during compilation — they
-carry a source line — so plain `TreatWarningsAsErrors` turns *those* into errors and the property
-never sees them. Under `CI=true` the trimmed publish failed outright, which meant **the gate that
-exists to measure trim warnings was the one thing that could not tolerate them**.
+**2. `ILLinkTreatWarningsAsErrors` does not do what its name suggests, and the conclusion drawn
+from that was wrong for two milestones.** The property feeds the ILLink *task*. Some `IL2xxx`
+findings instead come from the trim **Roslyn analyzer** at compile time, so plain
+`TreatWarningsAsErrors` turns *those* into errors and the property never sees them. Under `CI=true`
+the trimmed publish failed outright, which meant **the gate that exists to measure trim warnings was
+the one thing that could not tolerate them**.
 
-`NoWarn` would have been worse than useless: `eng/trim-ratchet.sh` **counts** these warnings, so
+That much is true. What this document used to say next is not: *"Most `IL2xxx` findings come from
+the trim Roslyn analyzer during compilation."* Measured in N30 against `artifacts/trim/publish.log`:
+
+| Emitter | Warning lines |
+|---|---|
+| ILLink task (`Trim analysis warning IL…`) | 1113 |
+| Roslyn analyzer (plain `warning IL…`) | **6** |
+
+Five of the six are the framework's own Razor output, one is EF Core's `ExecuteUpdateAsync`, and
+**none of InfoCarrier.Core's 88 came from the analyzer**. A `CI=true dotnet build -c Release` of the
+sample reported those five and nothing else, every time, for as long as the analyzer was on.
+
+So the analyzer was carrying no signal about this product and all of the cost, and N30 took it out
+of the ordinary build. The one signal it did carry — a new trim diagnostic in the *sample's* own
+code — moved to `eng/trim-baseline.txt` as a second gated owner, `northwind`, which is measured
+across the whole publish rather than across one compile.
+
+`NoWarn` was never an option and still is not: `eng/trim-ratchet.sh` **counts** these warnings, so
 silencing them reports `OURS: 0` and passes for ever — the exact failure its clean-publish rule
-already exists to prevent. The two axes are kept separate instead: warnings-as-errors gates the
-ordinary build, and the *direction* of the trim count gates the publish.
+already exists to prevent.
 
 ## Verified, in both directions
 
@@ -74,11 +118,11 @@ with a deliberately unused `using` in `src/InfoCarrier.Core/Expressions/TypeNode
 |---|---|
 | `dotnet build` (no `CI`) | exit **0**, reported as `warning IDE0005` |
 | `CI=true dotnet build` | exit **1**, `error IDE0005: Using directive is unnecessary.` |
-| `CI=true bash eng/trim-ratchet.sh` | exit **0**, `OURS: 88 <= 88` |
+| `CI=true bash eng/trim-ratchet.sh` | exit **0**, `ours OK (88 <= 88)` and `northwind OK (8 <= 8)` |
 
 ## Related gates, which this does not replace
 
 | Gate | Measures | Unaffected by this document |
 |---|---|---|
 | `eng/ratchet.sh` | spec-test failure **count**, against `test/known-failures.txt` | yes |
-| `eng/trim-ratchet.sh` | ILLink `IL2xxx` **direction**, against `eng/trim-baseline.txt` | yes — the C# compiler never emits `IL2xxx`, and those 88 are unfixable by design |
+| `eng/trim-ratchet.sh` | ILLink `IL2xxx` **direction** for two owners, `ours` and `northwind`, against `eng/trim-baseline.txt` | yes — those 88 are unfixable by design, and since N30 no ordinary build emits `IL2xxx` at all |

--- a/docs/plans/v10/implementation-plan.md
+++ b/docs/plans/v10/implementation-plan.md
@@ -2248,3 +2248,44 @@ rather than staying silent about it.
       **Gates: none.** No `src/`, no `test/`, and neither file is part of the site build. Every
       relative link in both files was resolved against the working tree, and every site URL against
       `mkdocs.yml`.
+
+- [x] **N30. One switch for the trim report, and the analyzer that was paying for nothing.** `<this commit>`
+
+      The trim gate had four moving parts: `SuppressTrimAnalysisWarnings=false` on every Release
+      build of the Blazor sample, a `WarningsNotAsErrors=IL2110;IL2111` to survive `CI=true`, a
+      `-p:TreatWarningsAsErrors=false` on the ratchet's own command line, and
+      `ILLinkTreatWarningsAsErrors=false` in the root props. Three of the four existed only to undo
+      the first.
+
+      **Measured before touching anything.** Splitting `artifacts/trim/publish.log` by emitter shape
+      gives **1113** lines from the ILLink task and **6** from the trim Roslyn analyzer. Five of the
+      six are the framework's own Razor output and one is EF's `ExecuteUpdateAsync`; **none of
+      InfoCarrier.Core's 88 came from the analyzer**. A `CI=true dotnet build -c Release` of the
+      sample reported exactly those five and nothing else. So the analyzer that cost three
+      suppressions was reporting nothing about this product.
+
+      It now turns on with **`-p:TrimReport=true`**, which `eng/trim-ratchet.sh` passes and nothing
+      else in the repository sets. One `PropertyGroup` in `Northwind.Client.csproj` holds all three
+      properties the report needs. The other two suppressions are deleted and the repository now
+      carries **no `WarningsNotAsErrors` at all** — a claim `Directory.Build.props` had been making
+      in prose while the sample contradicted it.
+
+      A side effect worth naming: the old `-p:TreatWarningsAsErrors=false` applied to every project
+      in the publish graph, so `InfoCarrier.Core` was built without the CI gate whenever the ratchet
+      ran. The switch is scoped to one project file, so it is not.
+
+      **The lost tripwire is replaced rather than mourned.** With the analyzer gone, a new trim
+      diagnostic in the sample's own code no longer fails CI, so `northwind=8` joins `ours=88` in
+      `eng/trim-baseline.txt` and the script gates both by direction. That measures the whole
+      publish instead of one compile, which is strictly more.
+
+      **A standing claim was wrong and is corrected in three files.** `docs/build-warnings.md` said
+      "most `IL2xxx` findings come from the trim Roslyn analyzer during compilation". It is 6 of
+      1119. The distinction it drew was real — the analyzer is why warnings-as-errors bit — but the
+      word "most" is what made the analyzer look load-bearing for two milestones. The same edit
+      closes the now-stale reason for `--configuration Release` in `CLAUDE.md`,
+      `Directory.Build.props` and `docs/build-warnings.md`: the rule stands, its original reason
+      does not.
+
+      **Gates: `CI=true dotnet build InfoCarrier.Core.slnx --configuration Release` and
+      `eng/trim-ratchet.sh`.** No `src/`, no `test/`, so no `eng/measure.sh`.

--- a/eng/trim-baseline.txt
+++ b/eng/trim-baseline.txt
@@ -47,5 +47,15 @@
 # `total` also falls, 1129 -> 853, and that is NOT this change: EF Core's own count dropped from 864
 # to 585 with the package/SDK movement since M8-17. Recorded so the next reader does not read a
 # 276-warning improvement as ours.
+# 2026-08-21 (N30) — `northwind` is gated from now on, and `ours` is unchanged at 88.
+#
+# The sample's own 8 warnings were reported and ungated until now. They are gated because N30 took
+# the trim ROSLYN ANALYZER out of the ordinary Release build, and that analyzer was the thing that
+# made a new trim diagnostic in the sample fail CI. It was measured first: of the publish's 1119 IL
+# warning lines, 1113 come from the ILLink task and 6 from the analyzer — five of those six are the
+# framework's own Razor output and one is EF's `ExecuteUpdateAsync`, and NONE of InfoCarrier.Core's
+# 88 came from it. So the analyzer carried no signal about this product and cost two suppressions to
+# keep, and the one signal it did carry — the sample's own code — is gated here instead.
 ours=88
+northwind=8
 total=853

--- a/eng/trim-ratchet.sh
+++ b/eng/trim-ratchet.sh
@@ -34,24 +34,19 @@ log="$out/publish.log"
 # pass forever while regressions sailed through. The count must come from a trimmer that RAN.
 rm -rf "$root/samples/Northwind.Client/obj/Release" "$root/samples/Northwind.Client/bin/Release"
 
-# TreatWarningsAsErrors is FORCED OFF for this publish, and it is not a loophole.
+# -p:TrimReport=true IS THE WHOLE SWITCH, and this is the only place in the repository that sets it.
 #
-# Directory.Build.props turns warnings into errors when CI=true. The trim analyzer emits its
-# IL2xxx findings as ordinary compiler warnings — they carry a source line, unlike the ILLink
-# step's own output — so under CI they became errors and the publish failed. The gate that
-# exists to MEASURE these warnings was the one thing that could not tolerate them.
+# It turns on SuppressTrimAnalysisWarnings=false, TrimmerSingleWarn=false and
+# TreatWarningsAsErrors=false together, all three declared in one PropertyGroup in
+# Northwind.Client.csproj. Everywhere else the trim diagnostics stay off, so no other build needs an
+# exemption to survive them and the repository carries no WarningsNotAsErrors at all.
 #
-# ILLinkTreatWarningsAsErrors does not help: it feeds the ILLink task, not the Roslyn analyzer.
-# NoWarn would be worse than useless — this script COUNTS these warnings, so silencing them
-# reports OURS: 0 and passes for ever, which is exactly the failure the clean-publish rule below
-# exists to prevent.
-#
-# So the two axes stay separate: warnings-as-errors gates the ordinary build, and the DIRECTION
-# of the trim count gates this one.
+# NoWarn would be worse than useless: this script COUNTS these warnings, so silencing them reports
+# OURS: 0 and passes for ever -- exactly the failure the clean-publish rule above exists to prevent.
 
 echo "trim-ratchet: publishing samples/Northwind.Client (Release, trimmed, clean)…"
 dotnet publish "$root/samples/Northwind.Client/Northwind.Client.csproj" \
-    -c Release --nologo -p:TreatWarningsAsErrors=false > "$log" 2>&1
+    -c Release --nologo -p:TrimReport=true > "$log" 2>&1
 status=$?
 
 if [ $status -ne 0 ]; then
@@ -118,6 +113,7 @@ def owner(diagnostic):
 tally = collections.Counter(owner(d) for _, d in unique)
 print(tally['InfoCarrier.Core'])
 print(len(unique))
+print(tally['Northwind'])
 for name, n in tally.most_common():
     print(f"{n}\t{name}")
 PY
@@ -125,6 +121,7 @@ PY
 
 ours=$(echo "$counts" | sed -n 1p)
 total=$(echo "$counts" | sed -n 2p)
+sample=$(echo "$counts" | sed -n 3p)
 
 if [ -z "$ours" ]; then
     echo "trim-ratchet: could not parse the publish log — see $log" >&2
@@ -132,25 +129,57 @@ if [ -z "$ours" ]; then
 fi
 
 echo
-echo "OURS: $ours   TOTAL (all assemblies): $total"
+echo "OURS: $ours   SAMPLE: $sample   TOTAL (all assemblies): $total"
 echo
-echo "$counts" | tail -n +3 | sed 's/^/    /'
+echo "$counts" | tail -n +4 | sed 's/^/    /'
 echo
 
-baseline=$(grep -E '^ours=' "$baseline_file" | cut -d= -f2)
-if [ -z "$baseline" ]; then
-    echo "trim-ratchet: no 'ours=' line in $baseline_file" >&2
-    exit 1
-fi
+# Two gated owners, and the second one is not padding.
+#
+# `ours` is the product and always was. `northwind` is the SAMPLE's own code, gated since N30 to
+# replace a tripwire that N30 removed: the trim analyzer used to run on every Release compile, so a
+# new trim diagnostic in the sample failed CI. That analyzer was measured to contribute 6 of this
+# publish's 1119 IL warning lines and none of InfoCarrier.Core's, so it went -- and the signal it
+# did carry moves here, onto the instrument that measures the whole publish rather than one compile.
+#
+# Everyone else is reported and not gated. EF Core alone contributes 585 and this repo does not get
+# to fix those.
+fail=0
+for owner in ours northwind; do
+    case "$owner" in
+        ours)     actual=$ours   ;;
+        northwind) actual=$sample ;;
+    esac
 
-if [ "$ours" -gt "$baseline" ]; then
-    echo "trim-ratchet: FAIL — InfoCarrier.Core trim warnings rose from $baseline to $ours." >&2
-    echo "Lower the baseline in the same commit as a fix; raise it only with a reason." >&2
-    exit 1
-fi
+    baseline=$(grep -E "^$owner=" "$baseline_file" | cut -d= -f2)
+    if [ -z "$baseline" ]; then
+        echo "trim-ratchet: no '$owner=' line in $baseline_file" >&2
+        exit 1
+    fi
 
-if [ "$ours" -lt "$baseline" ]; then
-    echo "trim-ratchet: improved ($baseline -> $ours). Lower 'ours=' in $baseline_file."
-fi
+    # BOTH SIDES MUST BE INTEGERS BEFORE THEY ARE COMPARED, and this is not defensive padding.
+    # `[ "$a" -gt "$b" ]` on a non-integer prints "integer expression expected" to STDERR and then
+    # takes the FALSE branch, so a mis-parsed count sails through as "OK" and the script exits 0.
+    # That happened while N30 was being written -- an off-by-one in which line of the counter's
+    # output was read fed a tab-joined "585 EFCore" into the comparison and the gate passed anyway.
+    for n in "$actual" "$baseline"; do
+        case "$n" in
+            ''|*[!0-9]*)
+                echo "trim-ratchet: $owner count is not a number: '$n'. See $log" >&2
+                exit 1
+                ;;
+        esac
+    done
 
-echo "trim-ratchet: OK ($ours <= $baseline)."
+    if [ "$actual" -gt "$baseline" ]; then
+        echo "trim-ratchet: FAIL — $owner trim warnings rose from $baseline to $actual." >&2
+        echo "Lower the baseline in the same commit as a fix; raise it only with a reason." >&2
+        fail=1
+    elif [ "$actual" -lt "$baseline" ]; then
+        echo "trim-ratchet: $owner improved ($baseline -> $actual). Lower '$owner=' in $baseline_file."
+    else
+        echo "trim-ratchet: $owner OK ($actual <= $baseline)."
+    fi
+done
+
+exit $fail

--- a/samples/Northwind.Client/Northwind.Client.csproj
+++ b/samples/Northwind.Client/Northwind.Client.csproj
@@ -13,43 +13,34 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
-  <!--
-    The trimming gate (spec §7). A Blazor release publish trims anyway; what these add is
-    VISIBILITY. The Blazor SDK sets SuppressTrimAnalysisWarnings=true by default, so a plain
-    publish reports nothing at all and a trim hole in this provider would ship unnoticed.
-
-    TrimmerSingleWarn=false expands the per-assembly summary into individual IL2xxx warnings, which
-    is the difference between "InfoCarrier.Core has trim warnings" and knowing which call site.
-  -->
+  <!-- THE APP RUNS TRIMMED, ALWAYS. That is a product claim, so it is unconditional. -->
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <PublishTrimmed>true</PublishTrimmed>
+  </PropertyGroup>
+
+  <!--
+    TRIM DIAGNOSTICS ARE OFF UNLESS THE RATCHET ASKS FOR THEM. `eng/trim-ratchet.sh` publishes with
+    -p:TrimReport=true, and nothing else in the repository sets it, so this one switch is the whole
+    mechanism.
+
+    A switch is needed at all because the Blazor SDK suppresses trim warnings by default: a plain
+    publish reports nothing, and a trim hole in this provider would ship unnoticed.
+    TrimmerSingleWarn=false expands the per-assembly summary into individual IL2xxx warnings, which
+    is the difference between "InfoCarrier.Core has trim warnings" and knowing which call site.
+    TreatWarningsAsErrors goes off HERE rather than on the ratchet's command line so that the switch
+    stays one property in one place.
+
+    This used to be on for every Release build, which cost two suppressions to survive `CI=true`: a
+    WarningsNotAsErrors exemption here and a -p:TreatWarningsAsErrors=false there. Neither was
+    buying anything. docs/build-warnings.md carries the measurement.
+
+    NOT NoWarn, and never NoWarn. eng/trim-ratchet.sh COUNTS these warnings, and silencing them is
+    how a ratchet starts reporting zero and passes for ever.
+  -->
+  <PropertyGroup Condition="'$(TrimReport)' == 'true'">
     <SuppressTrimAnalysisWarnings>false</SuppressTrimAnalysisWarnings>
     <TrimmerSingleWarn>false</TrimmerSingleWarn>
-
-    <!--
-      AND THIS IS WHAT MAKES THE LINE ABOVE SURVIVABLE IN CI. `SuppressTrimAnalysisWarnings=false`
-      turns the trim ROSLYN ANALYZER on for this project in Release. Since M8-32, `CI=true` also
-      sets `TreatWarningsAsErrors`. The two together turned five warnings in the **framework's own**
-      Razor output — `Router.NotFoundPage`, `LayoutView.Layout`, in `App_razor.g.cs`, none of them
-      this repository's code and none of them fixable here — into five build errors, and the CI
-      build had been red on every push since M8-32.
-
-      `ILLinkTreatWarningsAsErrors=false` in Directory.Build.props does NOT cover this. That
-      property governs the ILLink *task*, which runs at publish; these come from the *analyzer*, at
-      compile. The props file says exactly that, in a comment written after the same distinction
-      had already cost a run — the conclusion just was not carried this one step further.
-
-      NOT `NoWarn`, and not `TreatWarningsAsErrors=false`. Both would hide the diagnostics, and
-      `eng/trim-ratchet.sh` COUNTS them: silencing them is how a ratchet starts reporting zero and
-      passes for ever. These stay warnings, stay counted, and stay gated by direction against
-      eng/trim-baseline.txt.
-
-      TWO CODES, NOT THE WHOLE IL2xxx FAMILY, ON PURPOSE. A trim diagnostic this list does not name
-      still fails CI, which is the tripwire: it forces somebody to look at a new one before it is
-      tolerated. That is the same reasoning as the per-file `#pragma warning disable EF1001` rather
-      than a blanket NoWarn.
-    -->
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);IL2110;IL2111</WarningsNotAsErrors>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/README.md
+++ b/samples/README.md
@@ -226,8 +226,8 @@ made of, and `[DynamicallyAccessedMembers]` cannot describe them. The warnings m
 cannot *prove* the reflection safe for an arbitrary model, not that it broke this one.
 
 `eng/trim-ratchet.sh` gates the direction of that count against `eng/trim-baseline.txt`, exactly as
-`eng/ratchet.sh` gates the spec suite. Everyone else's warnings are reported but not gated — EF Core
-alone contributes 585 of the 853 total.
+`eng/ratchet.sh` gates the spec suite. It gates this sample's own 8 the same way. Everyone else's
+warnings are reported but not gated — EF Core alone contributes 585 of the 853 total.
 
 Both numbers have moved since they were first measured, in opposite directions and for unrelated
 reasons, which is why `eng/trim-baseline.txt` records each one rather than only the current value.


### PR DESCRIPTION
The trim gate had four moving parts. Three of them existed only to undo the first.

| | Where | Purpose |
|---|---|---|
| `SuppressTrimAnalysisWarnings=false` | `Northwind.Client.csproj`, every Release build | turn the trim diagnostics on |
| `WarningsNotAsErrors=IL2110;IL2111` | same file | survive `CI=true` |
| `-p:TreatWarningsAsErrors=false` | `eng/trim-ratchet.sh` command line | survive `CI=true` |
| `ILLinkTreatWarningsAsErrors=false` | `Directory.Build.props` | survive `CI=true` |

## Measured before anything was touched

Splitting `artifacts/trim/publish.log` by emitter shape:

| Emitter | Warning lines |
|---|---|
| ILLink task (`Trim analysis warning IL…`) | 1113 |
| Roslyn trim analyzer (plain `warning IL…`) | **6** |

Five of the six are the framework's own Razor output, one is EF's `ExecuteUpdateAsync`, and **none of InfoCarrier.Core's 88 came from the analyzer**. A `CI=true dotnet build -c Release` of the sample reported exactly those five and nothing else.

So the analyzer that cost three suppressions was reporting nothing about this product.

## What this does

One switch, `-p:TrimReport=true`, passed by `eng/trim-ratchet.sh` and set nowhere else. One `PropertyGroup` in `Northwind.Client.csproj` holds all three properties the report needs. The other two suppressions are deleted, and so is `ILLinkTreatWarningsAsErrors` — it defaults to `$(TreatWarningsAsErrors)`, which is false inside the switch and never consulted outside it.

The repository now carries **no `WarningsNotAsErrors` at all**, which is a claim `Directory.Build.props` had been making in prose while the sample contradicted it.

A side effect worth naming: the old `-p:TreatWarningsAsErrors=false` applied to every project in the publish graph, so `InfoCarrier.Core` was built without the CI gate whenever the ratchet ran. The switch is scoped to one project file, so it is not.

## The lost tripwire is replaced, not mourned

With the analyzer gone, a new trim diagnostic in the sample's own code no longer fails CI. So `northwind=8` joins `ours=88` in `eng/trim-baseline.txt` and the script gates both by direction — across the whole publish rather than one compile, which is strictly more.

Writing that turned up a live hazard in the old script: `[ "$a" -gt "$b" ]` on a non-integer prints to stderr and takes the **false** branch, so a mis-parsed count passes as `OK` and the script exits 0. It happened here, with a real off-by-one. Both sides are now checked to be integers first.

## A standing claim was wrong

`docs/build-warnings.md` said *"most `IL2xxx` findings come from the trim Roslyn analyzer during compilation"*. It is 6 of 1119. The distinction it drew was real — the analyzer is why warnings-as-errors bit — but "most" is what made the analyzer look load-bearing for two milestones. Corrected, with the measurement.

The same edit closes the now-stale reason for `--configuration Release` in `CLAUDE.md`, `Directory.Build.props` and `docs/build-warnings.md`. That rule was justified by "Release runs the trim analyzer, Debug does not", which stops being true here. The rule stands, because Release is what the server builds; its original reason does not.

## Gates, driven in both directions

| Command | Result |
|---|---|
| `CI=true dotnet build InfoCarrier.Core.slnx -c Release --no-incremental` | `0 Warning(s), 0 Error(s)` |
| … same command `-p:TrimReport=true` | `5 Warning(s), 0 Error(s)` — 2× `IL2110`, 8× `IL2111`, exit **0** |
| `CI=true bash eng/trim-ratchet.sh` | `OURS: 88   SAMPLE: 8   TOTAL: 853`; `ours OK`, `northwind OK`; exit **0** |
| … against a baseline saying `northwind=7` | `FAIL — northwind trim warnings rose from 7 to 8`; exit **1** |

No `src/` and no `test/`, so no `eng/measure.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
