### PR TITLE
Badges that say whether it works, and a Codespaces demo that costs nothing

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,16 +12,29 @@
 {
     "name": "InfoCarrier.Core",
 
-    // Ships the SDK already. Installing it through a devcontainer Feature instead adds an SDK
-    // download to every cold start, which is the slowest part of a start that has no prebuild.
-    // `global.json` pins 10.0.201 with rollForward=latestMinor, so this image must carry an SDK
-    // at that feature band or higher; if it ever lags, restore fails loudly rather than quietly.
-    "image": "mcr.microsoft.com/devcontainers/dotnet:1-10.0",
+    // A base image with no .NET, plus the SDK global.json pins, rather than a .NET image.
+    //
+    // THE FIRST ATTEMPT USED mcr.microsoft.com/devcontainers/dotnet:1-10.0 AND FAILED: that tag
+    // still ships 10.0.100-rc.2, global.json pins 10.0.201, and `dotnet build` exited 155 with
+    // "A compatible .NET SDK was not found". Codespaces then abandoned the container and dropped
+    // the visitor into an Alpine recovery container -- an image that lags is not a slow demo, it
+    // is no demo at all. The Feature installs an exact version, so this cannot drift.
+    //
+    // KEEP THIS VERSION AND global.json IN STEP. They are two statements of one fact.
+    "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+    "features": {
+        "ghcr.io/devcontainers/features/dotnet:2": { "version": "10.0.201" }
+    },
 
     // The SAMPLE, never InfoCarrier.Core.slnx. The solution holds the two test projects, and
     // restoring those pulls the EF Core specification-test packages -- minutes of download for a
     // visitor who wants to look at a grid.
-    "onCreateCommand": "dotnet build samples/Northwind.Server -c Debug",
+    //
+    // `|| true` IS DELIBERATE, and it is what the first failure taught. A non-zero exit here does
+    // not merely skip the build: it fails container creation, skips every later command, and hands
+    // the visitor a recovery container with no .NET in it. Letting the container come up puts the
+    // same error in the `demo` terminal below, where a person can read it.
+    "onCreateCommand": "dotnet build samples/Northwind.Server -c Debug || true",
 
     // Object form so the server gets its own named terminal: the log stays readable and the
     // visitor can stop it. The server hosts the Blazor client too, so this is the whole demo.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,45 @@
+// The "Try it in Codespaces" link in README.md lands here. It builds the sample and starts it,
+// so a visitor sees the running demo without typing a command.
+//
+// NO PREBUILD IS CONFIGURED, AND THAT IS THE POINT. Codespaces compute is billed to the account
+// that owns the codespace -- the visitor's, out of their monthly included hours -- so the demo
+// costs this repository nothing. Prebuild storage is the one thing billed to the repository
+// OWNER, which is why there is none. The price paid instead is the first-run wait below.
+//
+// IF A PREBUILD IS EVER ADDED: a prebuild runs `onCreateCommand` and `updateContentCommand` and
+// does NOT run `postCreateCommand`. The build below is therefore in `onCreateCommand`, so that
+// enabling a prebuild would warm it rather than silently skip it.
+{
+    "name": "InfoCarrier.Core",
+
+    // Ships the SDK already. Installing it through a devcontainer Feature instead adds an SDK
+    // download to every cold start, which is the slowest part of a start that has no prebuild.
+    // `global.json` pins 10.0.201 with rollForward=latestMinor, so this image must carry an SDK
+    // at that feature band or higher; if it ever lags, restore fails loudly rather than quietly.
+    "image": "mcr.microsoft.com/devcontainers/dotnet:1-10.0",
+
+    // The SAMPLE, never InfoCarrier.Core.slnx. The solution holds the two test projects, and
+    // restoring those pulls the EF Core specification-test packages -- minutes of download for a
+    // visitor who wants to look at a grid.
+    "onCreateCommand": "dotnet build samples/Northwind.Server -c Debug",
+
+    // Object form so the server gets its own named terminal: the log stays readable and the
+    // visitor can stop it. The server hosts the Blazor client too, so this is the whole demo.
+    "postAttachCommand": { "demo": "dotnet run --project samples/Northwind.Server" },
+
+    // The port in samples/Northwind.Server/Properties/launchSettings.json. `openPreview` opens
+    // the demo in a browser pane inside the editor as soon as the port opens.
+    "forwardPorts": [5199],
+    "portsAttributes": {
+        "5199": {
+            "label": "Northwind demo",
+            "onAutoForward": "openPreview"
+        }
+    },
+
+    "customizations": {
+        "vscode": {
+            "extensions": ["ms-dotnettools.csharp"]
+        }
+    }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,8 @@
 // NO PREBUILD IS CONFIGURED, AND THAT IS THE POINT. Codespaces compute is billed to the account
 // that owns the codespace -- the visitor's, out of their monthly included hours -- so the demo
 // costs this repository nothing. Prebuild storage is the one thing billed to the repository
-// OWNER, which is why there is none. The price paid instead is the first-run wait below.
+// OWNER, which is why there is none. The price paid instead is a first launch of about six
+// minutes, measured on the 2-core machine: base image, SDK, restore, build. A resume is seconds.
 //
 // IF A PREBUILD IS EVER ADDED: a prebuild runs `onCreateCommand` and `updateContentCommand` and
 // does NOT run `postCreateCommand`. The build below is therefore in `onCreateCommand`, so that

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,11 @@ jobs:
     name: Spec ratchet
     runs-on: ubuntu-latest
 
+    # Write access is for the `badges` branch only -- see the last step. Stated on the job rather
+    # than the workflow so the fast gate keeps the read-only default.
+    permissions:
+      contents: write
+
     steps:
       # Full history, because MinVer reads the version off the git tags and a shallow
       # clone has none. Without this the build still succeeds and silently produces a
@@ -106,6 +111,7 @@ jobs:
           --logger "trx;LogFileName=results.trx" --results-directory artifacts/test-results
 
       - name: Ratchet
+        id: ratchet
         run: ./eng/ratchet.sh artifacts/test-results/results.trx test/known-failures.txt
 
       - name: Upload results
@@ -114,3 +120,46 @@ jobs:
         with:
           name: test-results
           path: artifacts/test-results
+
+      # Publishes the numbers the ratchet just read to the `badges` branch, where shields.io reads
+      # them for README.md's spec-suite badge. The figures come from the counters file ratchet.sh
+      # writes, so the TRX is parsed once and by one parser.
+      #
+      # `always()`, because a run that FAILS the ratchet still has numbers and the badge should
+      # show them, in red. A badge frozen on the last green run is a badge that lies.
+      #
+      # AND NO SECRET. The usual recipe for this badge is a Gist plus a personal access token,
+      # which would be the first long-lived credential in this repository -- release.yml is built
+      # the way it is precisely to avoid having one. GITHUB_TOKEN can push, so it does. `badges`
+      # is an orphan branch holding this one file and sharing no history with main; the step fails
+      # loudly if that branch is missing rather than creating it, because a badge branch appearing
+      # by accident is how a badge starts pointing at nothing.
+      - name: Publish spec-suite badge
+        if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COLOR: ${{ steps.ratchet.outcome == 'success' && 'green' || 'red' }}
+        run: |
+          set -euo pipefail
+          . artifacts/test-results/counters.env
+
+          # 22658 -> 22,658. Five digits are hard to read in a badge without the separators.
+          comma() { echo "$1" | sed -E ':a;s/([0-9])([0-9]{3})($|,)/\1,\2\3/;ta'; }
+
+          work=$(mktemp -d)
+          git clone --depth 1 --branch badges \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$work"
+
+          printf '{"schemaVersion":1,"label":"spec suite","message":"%s / %s passing","color":"%s"}\n' \
+            "$(comma "$passed")" "$(comma "$total")" "$COLOR" > "$work/spec-suite.json"
+
+          cd "$work"
+          git add spec-suite.json
+          if git diff --staged --quiet; then
+            echo "Badge unchanged; nothing to push."
+            exit 0
+          fi
+          git -c user.name='github-actions[bot]' \
+              -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+              commit -m "Spec suite: ${passed} / ${total} passing"
+          git push

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ estimate a count, and never derive one figure from the others.
 |---|---|
 | `eng/measure.sh <label> [baseline]` | The way to measure a change. See below. |
 | `eng/trim-ratchet.sh [baseline]` | Publishes the Blazor sample trimmed and gates the direction of this product's `IL2xxx` count against `eng/trim-baseline.txt`. See below. |
-| `eng/ratchet.sh <results.trx> <baseline-file>` | **CI only**, and wired: `.github/workflows/build.yml`'s *spec-ratchet* job invokes it against `test/known-failures.txt`. The suite is legitimately red during build-out and tests must not be skipped to force it green, so CI gates on the *direction* of the failure count, and on the **total** as well. **It reads its figures out of the TRX**, which counts the skips the console block's `passed` and `failed` do not. |
+| `eng/ratchet.sh <results.trx> <baseline-file>` | **CI only**, and wired: `.github/workflows/build.yml`'s *spec-ratchet* job invokes it against `test/known-failures.txt`. The suite is legitimately red during build-out and tests must not be skipped to force it green, so CI gates on the *direction* of the failure count, and on the **total** as well. **It reads its figures out of the TRX**, which counts the skips the console block's `passed` and `failed` do not. It also writes them to `counters.env` beside the TRX, which is where the README's spec-suite badge gets its numbers — one parser, not two. |
 | `eng/docs-serve.sh [--build]` | Serves the documentation site locally with live reload; `--build` runs `mkdocs build --strict` instead. |
 | `eng/make-icon.py` | Regenerates `docs/assets/icon.png` from the source artwork. Run it when the artwork changes. |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,20 +188,22 @@ list in this file, is the current answer to "which bases are in".
 Query, projection split and SaveChanges work end-to-end. Lazy loading works: Phase L began at 505 of
 505 failing and stands at **825 of 825**.
 
-**`Total tests: 22656, Passed: 22466, Failed: 13, Skipped: 177`** (2026-08-17, `j15`).
+**`Total tests: 22658, Passed: 22472, Failed: 9, Skipped: 177`** (2026-08-18, `n8-minver`).
 **All four figures come out of the run's own summary block, and none of them is arithmetic** — a
 `c10b` entry once carried `Skipped` over from an earlier run and derived `Passed` from it. **A
 falling `total` with no note explaining it is a crashed host**: `test/known-failures.txt` records
 the one deliberate lowering, in C94, where two skipped theories turned 4 tests into 2.
 
-**All 13 failures are classified and not one is of unknown standing.** They sit in eight classes,
-five holding two and three holding one. The tables are in `docs/plans/v10/implementation-plan.md`
-— A54, A59, A61–A65, B3a–B16 and C1–C96 — and Phase J's "The residual 13, examined properly"
-re-derives the whole tail against M9's run. The run itself is in `artifacts/measure/`, currently
-`j15`. `Query.Associations` is 336 of 336, and `MaterializationInterception`,
-`OptimisticConcurrency` and `ComplexNavigations` are clear. Wrong answers are down to **2**, both
-C64's `Correlated_collection_with_distinct_3_levels`, whose assertion no correct answer can
-satisfy.
+**All 9 failures are classified and not one is of unknown standing.** They sit in six classes,
+three holding two and three holding one. The tables are in
+`docs/plans/v10/archive/implementation-plan-m9-phase-j.md` — A54, A59, A61–A65, B3a–B16 and
+C1–C96 — whose "The residual 13, examined properly" re-derives the whole tail **as it stood at
+thirteen**; J20 and J21 lowered it after that, and `test/known-failures.txt` carries the dated
+reading for each. **The archive is never edited, so its count is the count of the day it was
+written and the baseline file is the current one.** `Query.Associations` is 336 of 336, and
+`MaterializationInterception`, `OptimisticConcurrency` and `ComplexNavigations` are clear. Wrong
+answers are down to **2**, both C64's `Correlated_collection_with_distinct_3_levels`, whose
+assertion no correct answer can satisfy.
 
 **The consumer-facing statement of what is missing is
 [`website/docs/limitations.md`](website/docs/limitations.md)**, and that is the document to keep

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](license.txt)
 
 [**Documentation**](https://azabluda.github.io/InfoCarrier.Core/) &nbsp;·&nbsp;
-[**Try it in Codespaces**](https://codespaces.new/azabluda/InfoCarrier.Core?quickstart=1) &nbsp;·&nbsp;
 [Samples](samples/) &nbsp;·&nbsp;
+[**Try it in Codespaces**](https://codespaces.new/azabluda/InfoCarrier.Core?quickstart=1) &nbsp;·&nbsp;
 [Contributing](CONTRIBUTING.md)
 
 </div>

--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@
 
 **Use the full power of Entity Framework Core in a client application that has no database.**
 
+[![Build & Test](https://github.com/azabluda/InfoCarrier.Core/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/azabluda/InfoCarrier.Core/actions/workflows/build.yml)
+[![Spec suite](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fazabluda%2FInfoCarrier.Core%2Fbadges%2Fspec-suite.json)](https://github.com/azabluda/InfoCarrier.Core/actions/workflows/build.yml)
 [![NuGet](https://img.shields.io/nuget/vpre/InfoCarrier.Core?label=InfoCarrier.Core&color=004880)](https://www.nuget.org/packages/InfoCarrier.Core)
-[![NuGet](https://img.shields.io/nuget/vpre/InfoCarrier.Core.AspNetCore?label=InfoCarrier.Core.AspNetCore&color=004880)](https://www.nuget.org/packages/InfoCarrier.Core.AspNetCore)
-[![.NET 10](https://img.shields.io/badge/.NET-10.0-512BD4)](https://dotnet.microsoft.com/)
-[![EF Core 10](https://img.shields.io/badge/EF%20Core-10.0-512BD4)](https://github.com/dotnet/efcore)
+[![EF Core 10](https://img.shields.io/badge/EF%20Core-10.0%20on%20.NET%2010-512BD4)](https://github.com/dotnet/efcore)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](license.txt)
 
 [**Documentation**](https://azabluda.github.io/InfoCarrier.Core/) &nbsp;·&nbsp;
+[**Try it in Codespaces**](https://codespaces.new/azabluda/InfoCarrier.Core?quickstart=1) &nbsp;·&nbsp;
 [Samples](samples/) &nbsp;·&nbsp;
 [Contributing](CONTRIBUTING.md)
 

--- a/eng/ratchet.sh
+++ b/eng/ratchet.sh
@@ -50,6 +50,17 @@ done
 echo "Passed: ${passed}, Failed: ${failed}, Total: ${total}"
 echo "Baseline: failed=${baseline_failed}, total=${baseline_total} (${baseline_file})"
 
+# The spec-suite badge in README.md is built from these three numbers, and build.yml reads them
+# from here rather than parsing the TRX a second time: one parser, one place to fix. Written
+# before the gates below, because a run that fails the ratchet still has numbers worth publishing
+# -- the badge is meant to go red with them.
+counters_file="$(dirname "$trx")/counters.env"
+{
+    echo "total=${total}"
+    echo "passed=${passed}"
+    echo "failed=${failed}"
+} > "$counters_file"
+
 status=0
 
 if [ "$total" -lt "$baseline_total" ]; then

--- a/samples/README.md
+++ b/samples/README.md
@@ -14,8 +14,8 @@ a **console**. Both build the same `NorthwindContext` from `Northwind.Shared`, b
 
 Nothing to install: [**open it in Codespaces**](https://codespaces.new/azabluda/InfoCarrier.Core?quickstart=1)
 and `.devcontainer/devcontainer.json` builds the sample, starts the server and opens the demo. The
-first launch takes a couple of minutes, because there is no prebuild — see the comments in that
-file for why not.
+first launch takes about six minutes, measured, because there is no prebuild — see the comments
+in that file for why not. It is quick after that: a stopped codespace resumes in seconds.
 
 Locally it is one terminal, one command. The server hosts the client's files, so there is one
 origin and no CORS.

--- a/samples/README.md
+++ b/samples/README.md
@@ -12,7 +12,13 @@ a **console**. Both build the same `NorthwindContext` from `Northwind.Shared`, b
 
 ## Run it in a browser
 
-One terminal, one command. The server hosts the client's files, so there is one origin and no CORS.
+Nothing to install: [**open it in Codespaces**](https://codespaces.new/azabluda/InfoCarrier.Core?quickstart=1)
+and `.devcontainer/devcontainer.json` builds the sample, starts the server and opens the demo. The
+first launch takes a couple of minutes, because there is no prebuild — see the comments in that
+file for why not.
+
+Locally it is one terminal, one command. The server hosts the client's files, so there is one
+origin and no CORS.
 
 ```bash
 dotnet run --project samples/Northwind.Server


### PR DESCRIPTION
Four things, agreed in conversation: a shorter badge row with two *live* badges in it, and a
Codespaces demo that replaces the hosted-demo plan.

## The badge row

| Before | After |
|---|---|
| NuGet · NuGet (AspNetCore) · .NET 10 · EF Core 10 · MIT | Build & Test · spec suite · NuGet · EF Core 10 on .NET 10 · MIT |

- **Build & Test** — the row said what the project *is* and nothing about whether it works.
- **Spec suite** — `22,472 / 22,658 passing`, live. README.md has always claimed the provider is
  "judged by its test suite"; this is the number.
- **Dropped:** the second NuGet badge (`release.yml` publishes both packages from one tag at one
  version, so it could never disagree with the first) and `.NET 10` (joined into the EF Core
  badge). Downloads and a trim-safe badge were considered and dropped.

### How the spec-suite badge works, and why there is no PAT

`eng/ratchet.sh` already parses `total`/`passed`/`failed` out of the TRX, so it now also writes
them to `counters.env`; the new *Publish spec-suite badge* step formats them into a shields.io
endpoint document and pushes it to the orphan **`badges`** branch, which shields reads.

The usual recipe for this badge is a Gist plus a personal access token. **That token would be the
first long-lived credential in this repository**, and `release.yml` is built the way it is —
OIDC trusted publishing, no stored key — precisely to avoid one. `GITHUB_TOKEN` can push, so it
does, and `spec-ratchet` declares `contents: write` for it.

It publishes on `always()`: a run that fails the ratchet still has numbers, and a badge frozen on
the last green run is a badge that lies. A failing ratchet turns the badge red.

**The `badges` branch is already seeded** (from `artifacts/measure/n8-minver`: total 22658, passed
22472, failed 9 — the figures the current `test/known-failures.txt` baseline was written against),
so the badge renders in this PR rather than waiting up to ninety minutes for the first
spec-ratchet run after merge. Verified live: shields returns
`22,472 / 22,658 passing`, green.

## Codespaces

`.devcontainer/devcontainer.json` builds the sample, starts the server, and opens the demo in a
preview pane. The visitor types nothing.

**There is no prebuild, deliberately.** Per GitHub's billing documentation: codespace compute is
billed to *the account that owns the codespace* — the visitor's, from their monthly included hours
— and a visitor without a payment method is blocked rather than charged. Prebuild storage is the
one thing billed to the **repository owner**, so there is none. The price is a first launch of a
couple of minutes, which both READMEs state rather than letting it read as broken.

The build is in `onCreateCommand` even so, because a prebuild runs `onCreateCommand` and
`updateContentCommand` and **does not** run `postCreateCommand` — so enabling one later warms the
build instead of silently skipping it.

It builds `samples/Northwind.Server`, never the `.slnx`: the solution drags in the two test
projects and the EF Core specification-test packages with them.

**This replaces the hosted demo.** A forwarded Codespaces port is private, so the endpoint that
deserializes expression trees is never exposed to the internet, and every visitor gets a fresh
`northwind.db` — the per-session database, rate limiting and hardening that a public demo needed
are all unnecessary.

## Gates

`CLAUDE.md`'s table: this touches `docs/`-class text, `eng/` and CI only — no `src/`, no `test/` —
so neither `measure.sh` nor `trim-ratchet.sh` applies.

What was verified instead:
- `eng/ratchet.sh` run against a synthetic TRX: same verdicts as before, and `counters.env`
  written with `total=22656 passed=22466 failed=13`.
- `build.yml` parses as YAML, and the new step's script passes `bash -n`.
- `devcontainer.json` parses.
- The shields endpoint returns the right badge from the pushed `badges` branch.

## Still to check before merge

- [x] **The image's SDK band — checked, and it failed.** `mcr.microsoft.com/devcontainers/dotnet:1-10.0`
      ships `10.0.100-rc.2`; `global.json` pins `10.0.201`. `dotnet build` exited 155,
      `onCreateCommand` failed, container creation was abandoned and Codespaces served an Alpine
      recovery container — so `postAttachCommand` never ran and there was no demo. Fixed in
      df4525e: a plain base image plus the `dotnet` Feature at exactly `10.0.201` (verified
      downloadable), and the build is now `|| true` so a build failure can never again cost the
      whole container.

- [x] **A cold Codespaces start — measured at about six minutes** on the 2-core machine (base
      image, SDK, restore, build), and the preview pane opens by itself. Both READMEs and the
      devcontainer now carry that figure instead of a guess. A resume is seconds.

## Also in this branch

`CLAUDE.md`'s *Current state* was four failures behind: it read `22656 / 22466 / 13` from `j15`,
while `test/known-failures.txt` has said `9 / 22658` since J21 and the newest run in
`artifacts/measure` agrees (`n8-minver`: `22658 / 22472 / 9 / 177`). Corrected, along with the
pointer to the classification tables — `implementation-plan.md` was rewritten at the M9 boundary,
so those tables are in the Phase J archive now.

