### PR TITLE
Bulk operations do honour query filters, and the suite already said so

### DIFF
--- a/docs/doc-style.md
+++ b/docs/doc-style.md
@@ -31,8 +31,15 @@ The numbers below come from those files, not from memory. Re-measure before chan
 | Repository README | 450 | Npgsql: about 400. EF Core: about 700 for two products. |
 | A site page | 620 | The default |
 | A site page that points | 400 | `api-surface.md` only |
-| The deepest pages | 700 | `limitations`, `upgrading-from-3-1`, `release-notes`, `blazor-webassembly`, `security`, `guide/errors` |
-| Whole site | 10,000 | 9,473 today across 19 pages, from 9,578 across 18 |
+| The deepest pages | 700 | `limitations`, `upgrading-from-3-1`, `release-notes`, `blazor-webassembly`, `multi-tenancy` |
+| Two pages, provisionally | 750 | `security` and `guide/errors`, raised after the verification read of 2026-08-24 |
+| Whole site | not gated | 11,466 today across 23 files |
+
+The whole-site figure is a reading, not a gate. `eng/doc-words.py` checks each file against its own
+budget and nothing against the total, so a site-wide number here can only ever be a record of where
+the set stood the last time somebody measured it. It read 9,473 across 19 pages when this table was
+written and now reads 11,466 across 23, and the growth is four new pages plus the corrections the
+cold reads asked for.
 
 **`py eng/doc-words.py --all --budget` is the measurement, not `wc -w`.** `wc -w` counts fenced
 code, mermaid diagrams and the URL inside every link, so a page can be well inside its budget in

--- a/docs/plans/v10/cold-read-findings.md
+++ b/docs/plans/v10/cold-read-findings.md
@@ -65,8 +65,9 @@ from shared source, so a filter present on both is one the client declared, and 
 only on the server is one the server added on its own. The server can therefore honour an
 ignore-request for a named filter its client-visible model also has, and refuse it otherwise. **Not
 verified.** Before building it, check: what an unnamed (default) filter does under this rule, how
-the server learns which filters the client's model declares without trusting the client to say, and
-whether `ExecuteUpdate` and `ExecuteDelete` honour filters at all.
+the server learns which filters the client's model declares without trusting the client to say.
+(The third item on that list, whether `ExecuteUpdate` and `ExecuteDelete` honour filters at all, is
+answered below: they do.)
 
 ### Can the allowlist just refuse the marker? Checked, and no
 
@@ -100,12 +101,26 @@ Raised by the same two readers, not yet checked in source:
   another tenant's key. This is ordinary EF behaviour, and the pages pointed at query filters as
   the tenancy answer without saying the write path is a separate problem. `server.md` now says so;
   what the server should *do* about it is undecided.
-- **Do `ExecuteUpdate` and `ExecuteDelete` honour query filters?** Still unchecked, and it is an EF
-  Core semantics question rather than one about this provider. **Do not confuse it with the routing
-  question, which IS settled**: neither has a separate server path here, so both travel in the tree
-  and execute through the server's query provider like a query. That is why the read-side query
-  interceptor is the hook that sees them and a `SaveChanges` override is not, and it is what
-  `multi-tenancy.md` states. Whether EF then applies a filter to them is the open half.
+- **Do `ExecuteUpdate` and `ExecuteDelete` honour query filters? YES, and the answer was already
+  in this repository's own suite.** Closed 2026-08-24. It is an EF Core semantics question, and EF
+  answers it with a spec base: `FiltersInheritanceBulkUpdatesTestBase` runs the same delete and
+  update assertions against a model where `Animal` carries `HasQueryFilter(a => a.CountryId == 1)`,
+  and `InheritanceQueryFixtureBase.GetFilteredExpectedData` narrows the expected rows to match. A
+  provider that skipped the filter would fail every one of them on the row count.
+  **This provider adopts that base** as `FiltersInheritanceBulkUpdatesInfoCarrierTest`
+  (`test/InfoCarrier.Core.FunctionalTests/Sqlite/BulkUpdates/BulkUpdatesInfoCarrierTests.cs`), on
+  Tier B, and it is green: no `BulkUpdates` entry appears in `test/known-failures.txt`.
+  **The routing question was already settled and is a different one**: neither operation has a
+  separate server path here, so both travel in the tree and execute through the server's query
+  provider like a query. That is why the read-side query interceptor is the hook that sees them and
+  a `SaveChanges` override is not, and it is what `multi-tenancy.md` states.
+  **The consequence for tenancy is the uncomfortable half.** Because a filter reaches these
+  operations through the query pipeline, `IgnoreQueryFilters()` switches it off there too, and that
+  marker travels (§1 above). So `IgnoreQueryFilters().ExecuteDelete()` is the write-side version of
+  the read-side hole, and the same server-side interceptor is the same answer.
+  **The finding under the finding: a question filed as unchecked EF semantics was answered by a
+  test this repository already runs.** The cold read could not know that, but the standing rule
+  applies unchanged: grep the suite before calling something unverified.
 - **What else in `QueryMarkers` weakens a server-side guarantee?** `IgnoreAutoIncludes` and
   `AsTracking` are in the same set and were not examined.
 - **Is there any CPU, wall-clock, node-count or depth bound on evaluating a submitted tree?**
@@ -153,10 +168,16 @@ build, and two readers raised it independently.
 
 Real, and larger than a correction. Ordered by how often a reader hit them.
 
-1. **What happens when the WAN drops mid-unit-of-work.** Each page handles the failure it owns and
-   hands the cross-cutting case elsewhere: `transactions.md` defers failure to `errors.md`,
-   `errors.md` never mentions an open transaction, `saving-changes.md` never mentions transactions.
-   Nobody owns the most common production event.
+1. **What happens when the WAN drops mid-unit-of-work. CLOSED 2026-08-24.** Each page handled the
+   failure it owned and handed the cross-cutting case elsewhere: `transactions.md` deferred failure
+   to `errors.md`, `errors.md` never mentioned an open transaction, `saving-changes.md` never
+   mentioned transactions. Nobody owned the most common production event.
+   `errors.md` gained the open-transaction case in the round that followed this entry.
+   `saving-changes.md` now carries the other half: that a save which cannot fit in one request needs
+   a transaction, and that a transport failure leaves a save's outcome unknown rather than failed,
+   with both onward links. **The entry above was already half stale when it was read back**, which
+   is the recurring cost of a findings list that outlives the round it describes: check the page
+   before acting on the finding.
 2. **The split rule covers projections only.** `querying.md` explains an untranslatable projection.
    A helper method in a `Where` is what teams actually write, and the page's own hedge, "the
    projection usually tells you which one you are in", concedes the gap and stops.

--- a/docs/plans/v10/roadmap.md
+++ b/docs/plans/v10/roadmap.md
@@ -371,7 +371,12 @@ Three separable pieces, and only the first can be done outside the library:
 | Surviving more than one server instance | **library / deployment** | The registry is process-local, so a token only resolves on the instance that created it — horizontal scaling needs affinity or a shared registry. The sample is single-instance and does not hit this. |
 
 **Exit criteria**
-- HTTP transport binding (only in-process existed when this was written).
+- ~~HTTP transport binding~~ **DONE (M8-3, M8-4, promoted to the products in Phase K)** — only
+  in-process existed when this was written. `HttpInfoCarrierTransport` is the client half, in
+  `InfoCarrier.Core`; `MapInfoCarrier` is the server half, in `InfoCarrier.Core.AspNetCore`.
+  Both ship in the two packages, so nothing is left in `samples/`. **The Phase I note that said
+  this criterion "remains formally open" was true when it was written and is stale:** it
+  described the two files while they still lived beside the sample.
 - ~~gRPC transport binding~~ and ~~streaming results as `IAsyncEnumerable<T>`~~ **OUT OF SCOPE FOR
   v10, 2026-08-23, by the owner's decision.** Neither ships in the 10.x line. `IInfoCarrierTransport`
   is one method, so a gRPC binding stays a consumer-side class; the server continues to buffer a

--- a/eng/doc-words.py
+++ b/eng/doc-words.py
@@ -44,6 +44,14 @@ BUDGET = {
     # that is restructured, not before. See docs/plans/v10/cold-read-findings.md.
     "website/docs/security.md": 750,
     "website/docs/guide/errors.md": 750,
+
+    # Added to the 700 tier 2026-08-24. Same tier rule as the four above: it covers a whole
+    # subject rather than one task (reads, writes, resolving the tenant on the server, and what
+    # to test). It went over on the day `ExecuteUpdate` and `ExecuteDelete` were confirmed to
+    # honour query filters, which turned one clause about writes into two paragraphs because the
+    # two kinds of write now follow different rules. The signposting sentence the addition
+    # introduced was cut first, which is the order doc-style.md fixes; that recovered 10 of 45.
+    "website/docs/multi-tenancy.md": 700,
 }
 
 # RECALIBRATED TWICE, 2026-08-23 and 2026-08-24, and the second time is the signal. These numbers

--- a/website/docs/configuration/server.md
+++ b/website/docs/configuration/server.md
@@ -82,9 +82,8 @@ transaction. [Transactions](../guide/transactions.md) has that and what an aband
 
 A global query filter on the server's model applies to every query by default, which is what you
 want for your own honest client. **It is not a control.** `IgnoreQueryFilters()` is an ordinary EF
-Core operator: it travels in the expression tree like any other, and the server honours it. Query
-filters also do not apply to writes, so a client can submit a `SaveChanges` for a row whose key
-belongs to someone else.
+Core operator: it travels in the expression tree like any other, and the server honours it. No query
+filter reaches `SaveChanges`, so a client can submit a row whose key belongs to someone else.
 
 So put a write check in the server's `SaveChanges` override or an EF interceptor, and a read check
 in a query interceptor, which sees the client's tree before EF translates it.

--- a/website/docs/guide/saving-changes.md
+++ b/website/docs/guide/saving-changes.md
@@ -19,7 +19,8 @@ int written = await context.SaveChangesAsync();   // one round trip, returns 2
 ```
 
 One edit and one insert, one request. Batch your work into a unit rather than saving after every
-change.
+change. Work that cannot fit in one save needs a transaction, which holds the several requests on
+one server-side connection. See [Transactions](transactions.md).
 
 ## Store-generated values come back
 
@@ -120,4 +121,13 @@ not expose.
 
 A failure on the server, such as a constraint violation or a validation exception in an
 interceptor, arrives on the client as the exception EF would have thrown locally, with its message
-and inner chain preserved. See [Handling errors](errors.md).
+and inner chain preserved.
+
+A failure of the trip is a different case, and it is the one that costs data. `SaveChanges` is a
+single request, so a transport failure leaves the outcome unknown rather than failed: the request
+may have died on the way out, or the answer on the way back. Retrying it can write twice. If the
+save was one of several inside a transaction, that transaction is still open on the server and only
+the instance that began it can end it.
+
+[Handling errors](errors.md) has what is safe to retry and what is not, and
+[Transactions](transactions.md) has what an abandoned transaction costs.

--- a/website/docs/multi-tenancy.md
+++ b/website/docs/multi-tenancy.md
@@ -2,7 +2,7 @@
 
 The question for a multi-tenant server is what stops a caller reading another tenant's rows. A
 global query filter does not, on its own: `IgnoreQueryFilters()` travels in the expression tree and
-the server honours it, and filters never apply to writes. [Security](security.md) has that
+the server honours it, and no filter reaches `SaveChanges`. [Security](security.md) has that
 reasoning; this page is what to do instead.
 
 Keep the filters. They stop your own client leaking by accident and keep tenant predicates out of
@@ -24,10 +24,14 @@ predicate there, whatever the incoming tree says. The client cannot reach it.
 
 ## Writes
 
-A client can submit a `SaveChanges` for a row whose key belongs to another tenant, and no filter
-stands in the way. The check goes in the server's `SaveChanges` override or an EF interceptor, and
-a client can name neither. `ExecuteDelete` and `ExecuteUpdate` have no separate server path, so a
-`SaveChanges` override does not run for them; the query interceptor above guards those.
+`SaveChanges` is not a query, so no filter stands in its way and a client can submit a row whose key
+belongs to another tenant. The check goes in the server's `SaveChanges` override or an EF
+interceptor, and a client can name neither.
+
+`ExecuteDelete` and `ExecuteUpdate` translate from a query, so a filter does narrow the rows they
+touch. That is not a boundary either, because `IgnoreQueryFilters()` switches it off for them as it
+does for a read. Neither has a separate server path, so a `SaveChanges` override never runs for
+them, and the query interceptor above is what guards them.
 
 **Read the values you check from the store, not from the entity the client sent.** A client controls
 the original values in its own payload, so comparing the incoming row's tenant against the incoming


### PR DESCRIPTION
Closes the open half of cold-read finding §1. `ExecuteUpdate` and `ExecuteDelete` were filed as "unchecked EF Core semantics". EF answers it with a spec base this repository already adopts and already runs green.

## The answer, and where it came from

`FiltersInheritanceBulkUpdatesTestBase` runs the same delete and update assertions against a model carrying `HasQueryFilter(a => a.CountryId == 1)`, with `GetFilteredExpectedData` narrowing the expected rows to match. A provider that skipped the filter would fail every one of them on the row count.

This provider adopts it as `FiltersInheritanceBulkUpdatesInfoCarrierTest` on Tier B, and no `BulkUpdates` entry appears in `test/known-failures.txt`.

**The consequence for tenancy is the uncomfortable half.** Because the filter reaches these operations through the query pipeline, `IgnoreQueryFilters()` switches it off for them exactly as it does for a read. So `IgnoreQueryFilters().ExecuteDelete()` is the write-side version of the read-side hole, and the same server-side query interceptor is the same answer.

The finding under the finding: a question filed as unchecked EF semantics was answered by a test this repository already runs.

## What changed in the pages

Two pages carried the imprecise claim. "Filters never apply to writes" was true of `SaveChanges` and false of the other two kinds of write.

- `multi-tenancy.md` splits the Writes section by kind and states the `IgnoreQueryFilters` hole for bulk operations.
- `server.md` names `SaveChanges` instead of "writes".
- `multi-tenancy.md` moves to the 700-word tier. The signposting sentence the addition introduced was cut first, recovering 10 of the 45 words, which is the order `doc-style.md` requires.

## Also closed

**Documentation gap §3.1, the WAN dropping mid-unit-of-work.** `errors.md` gained the open-transaction case in a previous round; `saving-changes.md` now carries the other half and links both ways. The finding was already half stale when it was read back, and that is recorded where it sat.

**M8's HTTP-transport exit criterion is struck through.** `HttpInfoCarrierTransport` is in `InfoCarrier.Core` and `MapInfoCarrier` in `InfoCarrier.Core.AspNetCore`, both shipped. The Phase I note calling the criterion "formally open" described the two files while they still lived beside the sample.

**`doc-style.md`'s budget table is back in step with `eng/doc-words.py`.** The 750 tier was missing from it, and the whole-site figure it carried was a reading from 19 pages that the script never gated. It reads 11,466 across 23 now.

## Gates

`docs/`, `website/` and one budget dict, so neither ratchet applies.

- `mkdocs build --strict` exit 0
- `eng/doc-links.py`: 0 broken in 54 files
- `doc-words.py --all --budget`: 0 over
- 0 dashes in every user-facing file touched

All prose went through the `humanizer` skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
