### PR TITLE
Two deferrals to post-v10, and the first Native AOT measurement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,6 +224,19 @@ file to read before editing any of them.
   and **neither may be named as a plan in any user-facing document** (`doc-style.md` rule 6).
   `-preview` stays because the public surface is not settled, and **no user-facing document gives a
   reason for the suffix** — the version number carries it, as it does for every EF Core preview.
+- **The compiled-query cache keyed by canonical serialization (ADR-008 constraint 6, Q5) and the
+  server delegate cache (Q10) are OUT OF SCOPE for v10** (2026-08-24, owner's decision;
+  `roadmap.md`, M8 exit criteria). **It was never a correctness item**, which is why it could move:
+  EF's own `ICompiledQueryCache` already caches what the client's `CompileQuery` returns, so what
+  repeats per request is the serialize/translate work, and that gives the same answer every time.
+  **The suite measures answers, so a missing cache is invisible to it** — do not read 22472 passing
+  as evidence that this shipped. ADR-008 constraint 6 stays as written and stays unexercised.
+- **`IgnoreQueryFilters` is not refused by the server, and v10 ships that way** (2026-08-24,
+  owner's decision; `roadmap.md` §"`IgnoreQueryFilters`: why v10 ships with it open"). A global
+  query filter is therefore not an authorization boundary against a hostile client, for reads and
+  for `ExecuteUpdate`/`ExecuteDelete` alike. The documented control is a server-side query
+  interceptor. **Read `docs/plans/v10/cold-read-findings.md` §1 before touching the security or
+  tenancy prose**, and never let a user-facing page claim the filter is the boundary.
 - Two `ComplexTypesTracking` parameterizations: a property-bag complex *collection* on an `Added`
   entity. J22 traced it to an upstream defect on a path only this provider takes, and the route
   around it has to reproduce constructor binding, so it is priced and not taken.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,9 @@ Three levels, because each one hides a mistake the level below it catches:
 
 **Which gate to run before which commit.** `eng/measure.sh` says nothing about trimming and the trim
 gate says nothing about behaviour. They are separate axes, and M9's J8 was committed green on one
-while failing the other in CI.
+while failing the other in CI. **And neither says anything about Native AOT**: trimming does not ask
+whether code can be *generated*, so the 59 IL3050 diagnostics a `PublishAot` publish reports are
+invisible to `trim-ratchet.sh`. Nothing gates that axis, because Native AOT is not supported.
 
 | Change touches | Run |
 |---|---|
@@ -231,6 +233,15 @@ file to read before editing any of them.
   repeats per request is the serialize/translate work, and that gives the same answer every time.
   **The suite measures answers, so a missing cache is invisible to it** — do not read 22472 passing
   as evidence that this shipped. ADR-008 constraint 6 stays as written and stays unexercised.
+- **Native AOT is not supported, and it was measured rather than assumed** (2026-08-24;
+  `roadmap.md` M8 exit criteria, `findings.md`). A `PublishAot` publish of `samples/Northwind.Demo`
+  reports **155 unique IL diagnostics, 153 ours, and 59 of those are IL3050** —
+  `RequiresDynamicCode`, a code the trim analyzer never emits. **The trim ratchet therefore says
+  nothing about AOT and never did.** The publish also failed at the native link step for a missing
+  platform linker, so no native binary has been produced or run. `UseInfoCarrier` carries
+  `[RequiresUnreferencedCode]` and `[RequiresDynamicCode]`, as EF Core's own `DbContext`
+  constructors do; **that annotation did not lower the 88 and was not going to** — it exempts only
+  the annotated method's own body. Trimming itself is verified and works.
 - **`IgnoreQueryFilters` is not refused by the server, and v10 ships that way** (2026-08-24,
   owner's decision; `roadmap.md` §"`IgnoreQueryFilters`: why v10 ships with it open"). A global
   query filter is therefore not an authorization boundary against a hostile client, for reads and

--- a/docs/doc-style.md
+++ b/docs/doc-style.md
@@ -33,12 +33,12 @@ The numbers below come from those files, not from memory. Re-measure before chan
 | A site page that points | 400 | `api-surface.md` only |
 | The deepest pages | 700 | `limitations`, `upgrading-from-3-1`, `release-notes`, `blazor-webassembly`, `multi-tenancy` |
 | Two pages, provisionally | 750 | `security` and `guide/errors`, raised after the verification read of 2026-08-24 |
-| Whole site | not gated | 11,466 today across 23 files |
+| Whole site | not gated | 11,609 today across 23 files |
 
 The whole-site figure is a reading, not a gate. `eng/doc-words.py` checks each file against its own
 budget and nothing against the total, so a site-wide number here can only ever be a record of where
 the set stood the last time somebody measured it. It read 9,473 across 19 pages when this table was
-written and now reads 11,466 across 23, and the growth is four new pages plus the corrections the
+written and now reads 11,609 across 23, and the growth is four new pages plus the corrections the
 cold reads asked for.
 
 **`py eng/doc-words.py --all --budget` is the measurement, not `wc -w`.** `wc -w` counts fenced

--- a/docs/plans/v10/findings.md
+++ b/docs/plans/v10/findings.md
@@ -313,6 +313,44 @@ named it in one filtered run** (C19, 153 closed), and the same probe established
 that `ExecuteDelete` had never been broken at all. The standing probe rule is "establish that the
 code *ran*"; point it one step earlier — *where is this being cut* — before pricing a gap.
 
+**Native AOT was measured for the first time on 2026-08-24, and the measurement says the two axes
+are not one axis.** The trim ratchet has gated `samples/Northwind.Client` since M8-17 and reports 88
+diagnostics of ours. A `dotnet publish -r win-x64 -p:PublishAot=true` of the console sample
+(`samples/Northwind.Demo`) reports **155 unique IL diagnostics, 153 of them ours**, and the split is
+the finding: **59 are IL3050**, `RequiresDynamicCode`, a code the trim analyzer never emits because
+trimming does not ask whether code can be *generated*. So more than a third of the AOT picture is
+invisible to the gate this repository already runs, and "trimming is measured" was never evidence
+about AOT.
+
+**The publish did not finish, and the reason is the machine rather than the code.** It failed at the
+native link step with `Platform linker not found`: Native AOT on Windows needs the Desktop
+Development for C++ workload, which this machine does not have. ILCompiler's analysis had already
+run by then, which is why there is a number at all. **Nothing here proves a native binary would
+work**, and nobody should write that it does. `ubuntu-latest` ships clang, so CI could complete the
+link if this is ever worth gating.
+
+By file, ours concentrate exactly where the trim warnings do: `ProjectionRewriter` 26,
+`DynamicValueMapper` 18, `QuerySplitter` 16, `QueryExecutor` 14, `NodeToExpressionTranslator` 13.
+That is the provider's premise again, now with the second half named: the wire carries a type's
+name, the far end resolves it, **and then builds and compiles an expression tree over it**.
+`Expression.Lambda(...).Compile()` and `MakeGenericType` are what a remoting LINQ provider is made
+of, and Native AOT is the one runtime that cannot do either.
+
+**The two counts are not comparable and must not be subtracted.** They come from different samples
+(Blazor client versus console client), different tools (ILLink versus ILCompiler) and different
+unique-keys (`eng/trim-ratchet.sh` keys on code plus declaring member; the AOT tally keys on code
+plus file, line and column). 153 minus 88 is not a number that means anything.
+
+**What the annotation did, and did not do (2026-08-24).** `UseInfoCarrier` now carries
+`[RequiresUnreferencedCode]` and `[RequiresDynamicCode]`, which is what EF Core itself puts on
+`DbContext`'s constructors, checked in `subrepos/efcore` before it was copied. **It did not lower
+the 88, and the expectation that it would was wrong.** Those warnings sit in methods EF reaches
+through its own interfaces, not in anything reachable from `UseInfoCarrier`'s body, and the
+attribute exempts only the annotated method's own body. The ratchet measured 88 before and 88
+after. **What the attribute buys is a consumer being told at their own call site**, which is the
+thing that was missing: before it, a consumer publishing trimmed learned about this provider's
+reflection from EF Core's generic warning or from nothing at all.
+
 ## Two closed investigations
 
 **The runtime culture is pinned to invariant, and that was a ratchet fix rather than a test fix

--- a/docs/plans/v10/roadmap.md
+++ b/docs/plans/v10/roadmap.md
@@ -384,7 +384,20 @@ Three separable pieces, and only the first can be done outside the library:
   (requirements §4.4, wire-protocol W4) is deferred past this generation, not withdrawn.
   **Consequence for documentation:** neither may be named as a plan in any user-facing document
   (`docs/doc-style.md` rule 6), and neither is the reason the version says `-preview`.
-- Compiled-query cache keyed by canonical serialization (ADR-008 constraint 6, Q5).
+- ~~Compiled-query cache keyed by canonical serialization (ADR-008 constraint 6, Q5)~~ **OUT OF
+  SCOPE FOR v10, 2026-08-24, by the owner's decision.** It does not ship in the 10.x line.
+  **It was never a correctness item, and that is why it can move.** The client already avoids
+  repeating EF's compile work: EF's own `ICompiledQueryCache` caches what `IDatabase.CompileQuery`
+  returns, which is why `InfoCarrierDatabase` resolves the client per execution rather than
+  capturing it (`InfoCarrierDatabase.cs:93`). What repeats without this item is the serialize,
+  deserialize and translate work on each request, and that repetition gives the same answer every
+  time. The suite measures answers, so it cannot see this at all.
+  ADR-008 constraint 6 (canonical, deterministic serialization) stays as written and stays
+  unexercised; nothing in the code contradicts it. Q10, the server-side delegate cache, moves with
+  it, for the same reason and by the same decision.
+  **Consequence for documentation:** it may not be named as a plan in any user-facing document
+  (`docs/doc-style.md` rule 6). No user-facing document mentions caching today, so nothing needs
+  removing.
 - AOT/trimming verification (requirements §4.5).
 - ~~Sample apps~~ **DONE** (Phases H/I) — a Blazor WebAssembly client and a console client, both
   against a SQLite-backed ASP.NET Core server.
@@ -536,14 +549,46 @@ From wire-protocol §5 and research-findings §10 — resolved in the milestone 
 | W2 store-generated value keying (resolved §9, needs implementing) | M3 |
 | W3 transaction token | M4 |
 | W5 exception fidelity · W6 cancellation | M5 |
-| Q5 canonical form + compiled-query cache · Q10 server delegate cache | M8 |
+| Q5 canonical form + compiled-query cache · Q10 server delegate cache. **Out of scope for v10, 2026-08-24**, owner's decision; it is a latency item and never a correctness one (M8 above) | post-v10 |
 | Q6/W4 streaming vs identity resolution | M8 |
 | Server-held transaction lifetime: idle timeout, token ownership, multi-instance (see M8 above) | M8 |
 | ~~Q7 spatial Z/M via WKT~~ ✅ **done 2026-08-10** (C15/C17/C18, landed in M6) | ~~M7~~ |
-| **`IgnoreQueryFilters` crosses the wire and the server honours it**, so a global query filter is not an authorization boundary. Three strategies, one preferred, in [`cold-read-findings.md`](cold-read-findings.md) §1 | post-v10 |
+| **`IgnoreQueryFilters` crosses the wire and the server honours it**, so a global query filter is not an authorization boundary. Three strategies, one preferred, in [`cold-read-findings.md`](cold-read-findings.md) §1. **Deferred deliberately 2026-08-24**, owner's decision: v10 ships with this gap open, and the reasoning is below | post-v10 |
 | **Idempotency for a retried unit of work.** A transport failure leaves the outcome unknown and there is no request id to ask with. Same file, §2 | post-v10 |
 | **Nothing observable at runtime**: no logger category, no round-trip counter. Same file, §2 | post-v10 |
 | **Client/server version-skew policy.** The envelope carries a `ProtocolVersion`; nothing states what a fleet on mixed builds should expect. Same file, §2 | post-v10 |
+
+### `IgnoreQueryFilters`: why v10 ships with it open
+
+**Decided 2026-08-24 by the owner. v10 ships without a query filter that a hostile client cannot
+switch off.** Recording the reasoning here because a security-relevant gap that is deferred without
+one gets re-litigated, or worse, quietly forgotten.
+
+**It is deferred, not unmitigated.** The documented control is a query interceptor on the server,
+which re-applies the tenant predicate whatever the incoming tree says, and a client cannot reach it.
+Beside it sits the coarse control of the shared model: a type that must never leave the server goes
+on a context only the server has. `multi-tenancy.md` works both through and `security.md` carries the
+threat model, so a reader who follows the pages gets a boundary that holds. What v10 does not give is
+a boundary that holds for a reader who *ignores* the pages and reaches for a query filter, which is
+the natural thing to reach for.
+
+**The deferral has a scope, and it is only the honest-client case that is safe.** Two operations
+are affected, not one: `IgnoreQueryFilters()` disables the filter for reads, and it disables it for
+`ExecuteUpdate` and `ExecuteDelete` too, because those translate from a query
+(cold-read-findings §1). A `SaveChanges` never sees a filter at all. So the gap is read and bulk
+write, and the interceptor covers all three.
+
+**What deciding it later costs, checked before deferring.** Strategy (c), the preferred one, refuses
+an ignore-request for a filter the server added on its own while allowing one the client's model also
+declares. That needs a deny gate in `NodeToExpressionTranslator.Admit` and a per-filter decision the
+gate cannot make today, because it sees a method name and its arguments rather than the model. None
+of that is a wire-format change, and the envelope does not have to grow a field. So the decision does
+not get more expensive by waiting, which is the property that makes deferring it reasonable rather
+than convenient.
+
+**Two things that must not drift while it waits.** No user-facing document may claim a query filter
+is an authorization boundary, and none does today. And no document may name the fix as a plan
+(`docs/doc-style.md` rule 6).
 
 **[`cold-read-findings.md`](cold-read-findings.md) is the full record**, from seven readers who were
 each given a slice of the user-facing documentation, a persona and a task, and told to read only

--- a/docs/plans/v10/roadmap.md
+++ b/docs/plans/v10/roadmap.md
@@ -398,7 +398,23 @@ Three separable pieces, and only the first can be done outside the library:
   **Consequence for documentation:** it may not be named as a plan in any user-facing document
   (`docs/doc-style.md` rule 6). No user-facing document mentions caching today, so nothing needs
   removing.
-- AOT/trimming verification (requirements §4.5).
+- **AOT/trimming verification (requirements §4.5): trimming is verified, Native AOT is measured and
+  not supported.** §4.5 says "where feasible", and the two halves have different answers.
+  **Trimming: done.** The Blazor client publishes with `PublishTrimmed=true` and runs; M8-17 drove
+  all three pages against the published output. 88 IL diagnostics are ours and gated by direction
+  in `eng/trim-ratchet.sh`. The §4.5 clause about `System.Text.Json` source generators is met: the
+  envelope is source-generated (M8-11).
+  **Native AOT: measured 2026-08-24, and it is not a supported configuration for v10.** A
+  `PublishAot` publish of the console sample reports **155 unique IL diagnostics, 153 ours, of which
+  59 are IL3050** (`RequiresDynamicCode`) — a class the trim gate never sees. The provider builds
+  and compiles expression trees at run time from the payload, which is the one thing Native AOT
+  cannot do. **The publish also did not finish**: it failed at the native link step for a missing
+  platform linker on the measuring machine, so nothing proves a native binary would run either way.
+  Full account in [`findings.md`](findings.md).
+  **The honest annotation shipped instead of a fix.** `UseInfoCarrier` carries
+  `[RequiresUnreferencedCode]` and `[RequiresDynamicCode]`, matching what EF Core puts on
+  `DbContext`'s own constructors. It did not lower the 88 and was not expected to once the mechanism
+  was understood; it tells a consumer at their call site.
 - ~~Sample apps~~ **DONE** (Phases H/I) — a Blazor WebAssembly client and a console client, both
   against a SQLite-backed ASP.NET Core server.
 - ~~NuGet packaging, `release.yml`~~ **DONE (M8-19, M8-20, M8-22)** — **`InfoCarrier.Core`** and

--- a/eng/trim-baseline.txt
+++ b/eng/trim-baseline.txt
@@ -47,5 +47,21 @@
 # `total` also falls, 1129 -> 853, and that is NOT this change: EF Core's own count dropped from 864
 # to 585 with the package/SDK movement since M8-17. Recorded so the next reader does not read a
 # 276-warning improvement as ours.
+# 2026-08-24 — THIS FILE MEASURES TRIMMING AND SAYS NOTHING ABOUT NATIVE AOT. Recorded because the
+# two were read as one axis until they were measured separately. A `PublishAot` publish of
+# samples/Northwind.Demo reports 155 unique IL diagnostics, 153 of them ours, and 59 of those are
+# IL3050 (RequiresDynamicCode) -- a code the trim analyzer NEVER emits, because trimming does not
+# ask whether code can be GENERATED. So a third of the AOT picture is invisible here and always was.
+# That publish did not finish either: it failed at the native link step for a missing platform
+# linker, so no native binary has ever been produced or run. Native AOT is not a supported
+# configuration for v10 (roadmap.md, M8 exit criteria); this ratchet is not the thing that would
+# tell you if that changed. The two counts are NOT comparable and must not be subtracted: different
+# samples, different tools (ILLink vs ILCompiler), different unique-keys.
+#
+# 2026-08-24 — `ours` unchanged at 88 after `UseInfoCarrier` gained [RequiresUnreferencedCode] and
+# [RequiresDynamicCode]. Recorded because the opposite was expected. The attribute exempts only the
+# annotated method's OWN body, and these 88 sit in methods EF reaches through its own interfaces,
+# which `UseInfoCarrier` never calls. `total` rises 853 -> 854: the sample's call site now carries
+# its own IL2026, acknowledged with a narrow pragma in Program.cs rather than hidden project-wide.
 ours=88
-total=853
+total=854

--- a/samples/Northwind.Client/Program.cs
+++ b/samples/Northwind.Client/Program.cs
@@ -45,6 +45,19 @@ builder.Services.AddSingleton<IInfoCarrierClient>(services =>
 // A factory, not a context: each page owns its own unit of work, which is exactly what the Order
 // page is there to show. A DbContext held for the lifetime of the app would accumulate tracked
 // entities across pages and make "one SaveChanges for several edits" mean nothing.
+//
+// IL2026 IS ACKNOWLEDGED HERE, NOT SILENCED IN THE PROJECT FILE, AND THE DIFFERENCE IS THE POINT.
+// `UseInfoCarrier` carries [RequiresUnreferencedCode] and [RequiresDynamicCode] because this
+// provider resolves types by the name on the wire and builds expression trees at run time. That is
+// the provider telling a trimmed consumer the truth, and every consumer of a trimmed client meets
+// this warning at their own call site. THIS SAMPLE IS WHAT THEY DO ABOUT IT: acknowledge it where
+// the decision is made, having tested the paths this model uses -- which M8-17 did, driving all
+// three pages against the published trimmed output.
+//
+// A `WarningsNotAsErrors` entry beside IL2110/IL2111 would be wrong. Those two are the framework's
+// own Razor output, nothing here can fix them, and they are not about this call. This one is ours,
+// it is about this call, and hiding it project-wide would also hide the next one.
+#pragma warning disable IL2026 // UseInfoCarrier is [RequiresUnreferencedCode]; see above.
 builder.Services.AddDbContextFactory<NorthwindContext>((services, options) => options
     .UseInfoCarrier(services.GetRequiredService<IInfoCarrierClient>())
 
@@ -68,5 +81,6 @@ builder.Services.AddDbContextFactory<NorthwindContext>((services, options) => op
     // constructed on the side that enables them, plus a `LazyLoader` service property on that
     // side's model -- neither is something the wire names, and A49 is about names.
     );
+#pragma warning restore IL2026
 
 await builder.Build().RunAsync();

--- a/src/InfoCarrier.Core/InfoCarrierDbContextOptionsBuilderExtensions.cs
+++ b/src/InfoCarrier.Core/InfoCarrierDbContextOptionsBuilderExtensions.cs
@@ -1,5 +1,6 @@
 // Licensed under the MIT license. See license.txt file in the project root for license information.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
@@ -17,6 +18,14 @@ public static class InfoCarrierDbContextOptionsBuilderExtensions
     /// <param name="optionsBuilder">The options builder.</param>
     /// <param name="client">The client that ships operations to the server.</param>
     /// <returns>The same builder for chaining.</returns>
+    [RequiresUnreferencedCode(
+         "InfoCarrier resolves types by the name carried on the wire, so the trimmer cannot know "
+         + "which members a model needs and cannot be told with [DynamicallyAccessedMembers]. A trimmed "
+         + "client does run; test the paths your model actually uses. See "
+         + "https://azabluda.github.io/InfoCarrier.Core/platforms/blazor-webassembly/#trimming"),
+     RequiresDynamicCode(
+         "InfoCarrier builds and compiles expression trees at run time from the payload, and closes "
+         + "generic types over types the payload names, neither of which Native AOT can generate.")]
     public static DbContextOptionsBuilder UseInfoCarrier(
         this DbContextOptionsBuilder optionsBuilder,
         IInfoCarrierClient client)
@@ -40,6 +49,14 @@ public static class InfoCarrierDbContextOptionsBuilderExtensions
     /// <summary>
     ///     Configures the context to use the InfoCarrier provider (generic overload).
     /// </summary>
+    [RequiresUnreferencedCode(
+         "InfoCarrier resolves types by the name carried on the wire, so the trimmer cannot know "
+         + "which members a model needs and cannot be told with [DynamicallyAccessedMembers]. A trimmed "
+         + "client does run; test the paths your model actually uses. See "
+         + "https://azabluda.github.io/InfoCarrier.Core/platforms/blazor-webassembly/#trimming"),
+     RequiresDynamicCode(
+         "InfoCarrier builds and compiles expression trees at run time from the payload, and closes "
+         + "generic types over types the payload names, neither of which Native AOT can generate.")]
     public static DbContextOptionsBuilder<TContext> UseInfoCarrier<TContext>(
         this DbContextOptionsBuilder<TContext> optionsBuilder,
         IInfoCarrierClient client)

--- a/website/docs/limitations.md
+++ b/website/docs/limitations.md
@@ -181,6 +181,7 @@ These are not defects. They follow from where the client sits.
 | Automatic lazy loading does not work in Blazor WebAssembly | [Blazor WebAssembly](platforms/blazor-webassembly.md) |
 | A query result arrives in one response rather than as a stream, so a very large result set is a very large response. Page it. | |
 | Authentication and authorization are yours | [Security](security.md) |
+| Native AOT is not supported: remoting a query means compiling an expression tree at run time. Trimming is separate, and it works. | [Blazor WebAssembly](platforms/blazor-webassembly.md#trimming) |
 
 ## What this page cannot tell you
 


### PR DESCRIPTION
Stacked on [#35](https://github.com/azabluda/InfoCarrier.Core/pull/35). Review that one first, or read only the last two commits here.

## Two deferrals to post-v10 (8f65f11)

Owner's decision, 2026-08-24. Neither is a code change, and that is the point: a scope change belongs in `roadmap.md`, not in a commit that quietly stops doing something.

**The compiled-query cache (Q5, ADR-008 constraint 6) and the server delegate cache (Q10)** leave M8's exit criteria. It was never a correctness item, which is what makes it movable: EF's own `ICompiledQueryCache` already caches what the client's `CompileQuery` returns, so what repeats per request is the serialize, deserialize and translate work, and that gives the same answer every time. **The suite measures answers, so 22,472 passing tests are not evidence the cache shipped.** ADR-008 constraint 6 stays as written and stays unexercised, so nothing in the code contradicts the ADR.

**`IgnoreQueryFilters` stays honoured by the server, and v10 ships that way.** The row was already marked post-v10; what was missing was the reasoning. The new section records that the gap is deferred rather than unmitigated (a server-side query interceptor is the documented control, with the shared model as the coarse one), that it covers reads and `ExecuteUpdate`/`ExecuteDelete` but never `SaveChanges`, and that deferring costs nothing later: strategy (c) needs a deny gate and a per-filter decision, but no wire-format change and no new envelope field.

## Native AOT, measured for the first time (6f5cb42)

**155 unique IL diagnostics, 153 of them ours, and 59 of those are IL3050.**

IL3050 is `RequiresDynamicCode`, which the trim analyzer never emits, because trimming does not ask whether code can be *generated*. More than a third of the AOT picture was always invisible to the ratchet this repository already runs.

The cause is the provider's premise, second half: the wire carries a type's name, the far end resolves it, **and then builds and compiles an expression tree over it**. `Expression.Lambda(...).Compile()` and `MakeGenericType` are what a remoting LINQ provider is made of, and Native AOT is the one runtime that can do neither.

**The publish did not finish**, and that is recorded everywhere the number is. It failed at the native link step for a missing platform linker on the measuring machine. Nothing here proves a native binary would run, and no document says it does.

## The annotation, and what it did not do

`UseInfoCarrier` carries `[RequiresUnreferencedCode]` and `[RequiresDynamicCode]`, which is what EF Core puts on `DbContext`'s own constructors (checked in `subrepos/efcore` before copying).

**It did not lower the 88, and the expectation that it would was wrong.** The attribute exempts only the annotated method's own body; those 88 sit in methods EF reaches through its own interfaces, which `UseInfoCarrier` never calls. The ratchet measured 88 before and 88 after. What it buys is a consumer being told at their own call site.

The Blazor sample's call site now raises IL2026, which is how we know the annotation reaches consumers. It is acknowledged there with a narrow pragma rather than added to the project's `WarningsNotAsErrors`, because those two entries are the framework's own Razor output and this one is ours.

Consumers get one row in `limitations.md`. It is deliberately **not** on the Blazor page: Blazor WASM AOT (`RunAOTCompilation`) is a different technology from Native AOT and was not measured.

## Gates

- `CI=true dotnet build --configuration Release`: 0 Error(s), 5 Warning(s), all pre-existing framework Razor IL2110/IL2111
- `eng/trim-ratchet.sh`: OK (88 <= 88); total 853 to 854, the sample's own new diagnostic
- `eng/measure.sh aot-annotations d7-metadata`: `Total tests: 22658, Passed: 22472, Failed: 9, Skipped: 177`. FIXED none, BROKEN none, REASONS unchanged. All four figures read from the run's own summary block.
- `mkdocs build --strict` exit 0, `doc-links.py` 0 broken in 54 files, `doc-words.py --all --budget` 0 over

🤖 Generated with [Claude Code](https://claude.com/claude-code)
