### PR TITLE
A scalar parameter reached the server as a literal, so the store saw no parameter

### DIFF
--- a/docs/research-findings.md
+++ b/docs/research-findings.md
@@ -159,6 +159,39 @@ never produces): Block/Loop/Try/Goto/Switch/Label/DebugInfo/Throw/Dynamic. EF ex
 > substitutes EF's extracted parameters back in as constants, and **a constant is a different thing
 > to EF than a parameter is**. Only a wire primitive is safe to inline.
 
+> ⚠️ **Superseded for WIRE PRIMITIVES too, 2026-08-27 (issue #59), which reverses the original rule
+> rather than narrowing it. "Scalars are unchanged" is now false, and the last sentence above is
+> the one that was wrong.** A wire primitive is not safe to inline either, and the reason is one
+> nobody here had looked at: **nothing in this suite has ever read the SQL the server generates.**
+> `InfoCarrierTestStoreFactory` builds a `TestSqlLoggerFactory`, but it belongs to the *client*,
+> which has no database and emits none, and `InfoCarrierBackendTestStore` wires no logger at all.
+>
+> **Measured** by attaching `LogTo` to the server context through
+> `SharedTestStoreProperties.OnAddOptions`. `Where(b => b.Title == title)` reached SQLite as
+> `WHERE "b"."Title" = 'beta'` with `[Parameters=[]]`, where the same query written directly
+> against the server context produced `WHERE "b"."Title" = @title`. So every distinct value was a
+> distinct statement, and — by this section's own J21 observation about
+> `ExpressionEqualityComparer.CompareConstant` — a distinct entry in the server's compiled-query
+> cache. `Contains` and `Skip`/`Take` were already correct, which is what made the boundary
+> visible.
+>
+> **Boxing invents no parameterization.** `Substitute` is reached only for a node EF's own
+> funcletizer already made a parameter on the client, and `EF.Constant` is excluded by
+> `_insideEFCall`. The box restores a decision the wire discarded.
+>
+> **One new guard, and the first full run found it.** A scalar inside an inline collection the
+> caller wrote — `c.Ints == new[] { i, j }` — must stay a constant. Boxed, every element becomes an
+> evaluatable member read, EF folds the whole array into a single parameter, and the
+> inline-collection shape is gone; `Column_collection_equality_inline_collection_with_parameters`
+> failed on exactly that. `_insideInlineCollection` is the guard. **This is the 2026-08-02
+> amendment seen from the other side**: that one spelled a collection out so relational EF would
+> see the shape, this one declines to take the shape apart.
+>
+> **0 fixed, 0 broken, 9 failures unchanged across 22,666** (`issue59-v2`). The suite could not
+> have found this, because it compares answers and the answers were always right.
+> `ServerParameterizationTest` is the differential test that can: same query over the wire and
+> directly against the server, statements compared after normalizing parameter names.
+
 v1's bug: wrapping parameter values in a custom generic struct `ValueWrapper<T>` as a tree
 constant broke translation. **Rule:** substitute compiled-query parameters as **plain
 `ConstantExpression` of the runtime value** (typed to the parameter's type), resolved from

--- a/src/InfoCarrier.Core/QueryExecutor.cs
+++ b/src/InfoCarrier.Core/QueryExecutor.cs
@@ -549,6 +549,50 @@ internal sealed class QueryExecutor<TElement>
                     ? Substitute(WithoutNullEntities(value, queryParameter.Type), queryParameter.Type)
                     : base.VisitExtension(node);
 
+        /// <summary>
+        ///     Whether the visit is inside an inline collection the caller wrote out — a
+        ///     <c>new[] { i, j }</c> or a <c>new List&lt;int&gt; { i, j }</c>.
+        /// </summary>
+        /// <remarks>
+        ///     <para>
+        ///         A scalar inside one stays a plain constant, and this is issue #59's one
+        ///         exception. Boxing makes every element an evaluatable member read, so EF's
+        ///         funcletizer folds the <em>whole array</em> into a single parameter and the
+        ///         inline-collection shape is gone. `Column_collection_equality_inline_collection_with_parameters`
+        ///         is the test that says so: `c.Ints == new[] { i, j }` then reaches SQL as a
+        ///         column compared to one array parameter, which nothing translates.
+        ///     </para>
+        ///     <para>
+        ///         This is §6's 2026-08-02 amendment seen from the other side. That one spelled a
+        ///         collection <em>out</em> so relational EF would recognise the shape; this one
+        ///         declines to take the shape apart for the same reason. EF keeps the shape for
+        ///         itself because its elements are real <c>QueryParameterExpression</c>s, which
+        ///         this side cannot produce — the client captures downstream of them (ADR-006).
+        ///     </para>
+        /// </remarks>
+        private bool _insideInlineCollection;
+
+        protected override Expression VisitNewArray(NewArrayExpression node)
+            => VisitInlineCollection(node, base.VisitNewArray);
+
+        protected override Expression VisitListInit(ListInitExpression node)
+            => VisitInlineCollection(node, base.VisitListInit);
+
+        private Expression VisitInlineCollection<TNode>(TNode node, Func<TNode, Expression> visit)
+            where TNode : Expression
+        {
+            bool outer = _insideInlineCollection;
+            _insideInlineCollection = true;
+            try
+            {
+                return visit(node);
+            }
+            finally
+            {
+                _insideInlineCollection = outer;
+            }
+        }
+
         protected override Expression VisitMethodCall(MethodCallExpression node)
         {
             if (node.Method.DeclaringType != typeof(EF))
@@ -645,7 +689,9 @@ internal sealed class QueryExecutor<TElement>
         /// </summary>
         /// <remarks>
         ///     <para>
-        ///         A <b>scalar</b> is a plain constant, which is §6's rule and is unchanged.
+        ///         A <b>scalar</b> is boxed as well, since issue #59. §6 originally made it a
+        ///         plain constant, and a constant reaches the backing store as a SQL
+        ///         <em>literal</em> rather than a SQL parameter.
         ///     </para>
         ///     <para>
         ///         A <b>collection</b> is boxed, so that the server's own funcletizer lifts it back
@@ -720,10 +766,31 @@ internal sealed class QueryExecutor<TElement>
             // *value* the caller stores, and EF's own providers carry it as a parameter with the
             // property's converter applied. `IOrderedEnumerable<T>` is never a property type, and
             // neither is an anonymous type.
-            if (!PrimitiveCoercion.IsWirePrimitive(parameterType)
-                && parameterType != typeof(object)
-                && _queryContext.Context.Model.FindRuntimeEntityType(parameterType) is null
-                && IsMappedPropertyType(_queryContext.Context.Model, parameterType))
+            // **A wire primitive is boxed too, since 2026-08-27 (issue #59), and this reverses
+            // §6's original rule rather than narrowing it.** §6 said a scalar becomes a plain
+            // constant. Measured on the SQLite tier by logging the *server's*
+            // `RelationalEventId.CommandExecuted`, that produced `WHERE "b"."Title" = 'beta'` with
+            // `[Parameters=[]]`, where the same query written directly against the server context
+            // produced `WHERE "b"."Title" = @title`. Every distinct value is therefore a distinct
+            // statement and — because `ExpressionEqualityComparer.CompareConstant` reads tree
+            // constants into the key — a distinct entry in the server's compiled-query cache.
+            //
+            // **Boxing here invents nothing.** This method is reached only from the two visitors
+            // above, and only for a node EF's *own* funcletizer already decided was a parameter on
+            // the client. A literal the caller wrote in source never arrives here, and
+            // `EF.Constant` is excluded one level up by `_insideEFCall`. So the box restores the
+            // decision the wire discarded.
+            //
+            // The J21 clauses below are kept as they were, and each still excludes a type the box
+            // cannot carry: `object` (whose real type differs per value), an entity type (which EF
+            // expands to a key comparison itself), and anything the model does not store as a
+            // property — an anonymous type is the case that matters, and `IOrderedEnumerable<T>`
+            // is already excluded by the collection branch above.
+            if (!_insideInlineCollection
+                && (PrimitiveCoercion.IsWirePrimitive(parameterType)
+                    || (parameterType != typeof(object)
+                        && _queryContext.Context.Model.FindRuntimeEntityType(parameterType) is null
+                        && IsMappedPropertyType(_queryContext.Context.Model, parameterType))))
             {
                 return Boxed(value, parameterType);
             }

--- a/src/InfoCarrier.Core/QueryExecutor.cs
+++ b/src/InfoCarrier.Core/QueryExecutor.cs
@@ -786,8 +786,36 @@ internal sealed class QueryExecutor<TElement>
             // expands to a key comparison itself), and anything the model does not store as a
             // property — an anonymous type is the case that matters, and `IOrderedEnumerable<T>`
             // is already excluded by the collection branch above.
+            // **An `object`-typed parameter is boxed too, since 2026-08-27 (issue #59), and it is
+            // not an edge case: it is `Find()`.** EF's `ExpressionExtensions.BuildPredicate` builds
+            // a key lookup as `EF.Property<object>(e, name) == keyValues[i]` whenever the key is a
+            // non-numeric value type — a `Guid` above all — so the parameter's declared type is
+            // `object` and the J21 guard below excluded it. A layer-1 sweep of the whole suite
+            // counted **3,927 of these in the SQLite tier alone**, every one reaching the store as
+            // a literal where EF's own client sends a parameter.
+            //
+            // The declared type stays `object`. EF compares against `keyValues[i]`, an indexer
+            // returning `object`, on this very path, so an object-typed parameter is a shape EF
+            // already handles here. Re-typing the box to the runtime type would change what
+            // `CreateEqualsExpression` is given.
+            //
+            // **The runtime type is read here, and that is the exception to J19's rule, not a
+            // lapse from it.** Every other clause decides from `parameterType` because the declared
+            // type is the honest question. `object` is the one declared type that answers nothing,
+            // so there is nothing else to ask. The first attempt boxed on the declared type alone
+            // and broke 21 `KeysWithConvertersInfoCarrierTest` tests with *"Object must implement
+            // IConvertible"* — a `BytesStructKey` is not a value the wire carries as a primitive,
+            // and `object` had hidden that. Restricting to a wire-primitive runtime type keeps the
+            // `Guid` and `DateTime` key lookups and leaves the converted struct keys alone.
+            //
+            // A null is left alone. §6's caution about `object` is about a collection's *element*
+            // type, where elements of differing real types tell EF less spelled out than gathered;
+            // that is the branch above, and this one is a scalar.
             if (!_insideInlineCollection
                 && (PrimitiveCoercion.IsWirePrimitive(parameterType)
+                    || (parameterType == typeof(object)
+                        && value is not null
+                        && PrimitiveCoercion.IsWirePrimitive(value.GetType()))
                     || (parameterType != typeof(object)
                         && _queryContext.Context.Model.FindRuntimeEntityType(parameterType) is null
                         && IsMappedPropertyType(_queryContext.Context.Model, parameterType))))

--- a/test/InfoCarrier.Core.FunctionalTests/Sqlite/ServerParameterizationTest.cs
+++ b/test/InfoCarrier.Core.FunctionalTests/Sqlite/ServerParameterizationTest.cs
@@ -1,0 +1,152 @@
+// Licensed under the MIT license. See license.txt file in the project root for license information.
+
+using System.Text.RegularExpressions;
+using InfoCarrier.Core.FunctionalTests.TestUtilities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Xunit;
+
+namespace InfoCarrier.Core.FunctionalTests.Sqlite;
+
+/// <summary>
+///     Asserts that a query which crosses the wire reaches the backing store as the <em>same
+///     statement</em> as the one written directly against the server context (issue #59).
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>This is a differential test and deliberately not a baseline one.</b> EF's relational
+///         spec bases pin generated SQL against golden strings, which here would pin SQLite's
+///         dialect — the backend's business, tested by EF, and not observable from this client.
+///         The question this repository has to answer is different: <em>does the middleman between
+///         the caller's LINQ and the store's SQL change the statement?</em> Running the same query
+///         both ways and comparing answers that question without a single golden string, and it
+///         survives an EF version bump.
+///     </para>
+///     <para>
+///         <b>Parameter names are normalized before the comparison, and that is not laziness.</b>
+///         A parameter reaches the server inside a <c>ParameterBox&lt;T&gt;</c>, so EF names it
+///         after the box's property and the caller's local variable name never crosses the wire.
+///         <c>@Value</c> against <c>@title</c> is the expected difference; <c>'beta'</c> against
+///         <c>@title</c> is the defect.
+///     </para>
+///     <para>
+///         The SQL is captured from the <b>server</b> context, through the
+///         <see cref="SharedTestStoreProperties.OnAddOptions" /> hook. Nothing else in this suite
+///         looks at server SQL: <c>InfoCarrierTestStoreFactory</c>'s <c>TestSqlLoggerFactory</c>
+///         belongs to the client, which has no database and emits none.
+///     </para>
+/// </remarks>
+public partial class ServerParameterizationTest
+{
+    private readonly List<string> _sink = [];
+
+    [ConditionalFact]
+    public Task A_scalar_string_parameter_stays_a_parameter()
+        => AssertSameStatement(
+            "beta",
+            static (blogs, title) => blogs.Where(b => b.Title == title));
+
+    [ConditionalFact]
+    public Task A_scalar_int_parameter_stays_a_parameter()
+        => AssertSameStatement(
+            2,
+            static (blogs, minId) => blogs.Where(b => b.Id >= minId));
+
+    [ConditionalFact]
+    public Task A_collection_parameter_stays_an_IN_list()
+        => AssertSameStatement(
+            new List<string> { "alpha", "gamma" },
+            static (blogs, titles) => blogs.Where(b => titles.Contains(b.Title!)));
+
+    [ConditionalFact]
+    public Task A_limit_and_offset_stay_parameters()
+        => AssertSameStatement(
+            2,
+            static (blogs, take) => blogs.OrderBy(b => b.Id).Skip(1).Take(take));
+
+    /// <summary>
+    ///     Runs <paramref name="query" /> over the wire and again directly against the server, and
+    ///     asserts the store saw one statement, not two.
+    /// </summary>
+    private async Task AssertSameStatement<TValue>(
+        TValue value,
+        Func<IQueryable<Blog>, TValue, IQueryable<Blog>> query)
+    {
+        await using SqliteInfoCarrierBackendTestStore store = CreateStore();
+        await store.InitializeAsync(
+            store.ServiceProvider,
+            store.CreateDbContext,
+            seed: async context =>
+            {
+                context.AddRange(
+                    new Blog { Id = 1, Title = "alpha" },
+                    new Blog { Id = 2, Title = "beta" },
+                    new Blog { Id = 3, Title = "gamma" });
+                await context.SaveChangesAsync();
+            });
+
+        Drain();
+
+        await using (SqliteSmokeContext client = new(
+            new DbContextOptionsBuilder<SqliteSmokeContext>().UseInfoCarrier(store).Options))
+        {
+            _ = await query(client.Blogs, value).ToListAsync();
+        }
+
+        string overTheWire = SingleStatement(Drain());
+
+        using (DbContext server = store.CreateDbContext())
+        {
+            _ = await query(server.Set<Blog>(), value).ToListAsync();
+        }
+
+        string directly = SingleStatement(Drain());
+
+        Assert.Equal(directly, overTheWire);
+    }
+
+    private SqliteInfoCarrierBackendTestStore CreateStore()
+        => new(
+            Guid.NewGuid().ToString(),
+            shared: false,
+            new SharedTestStoreProperties
+            {
+                ContextType = typeof(SqliteSmokeContext),
+                OnModelCreating = (_, _) => { },
+                OnAddOptions = b => b.LogTo(
+                    line => { lock (_sink) { _sink.Add(line); } },
+                    [RelationalEventId.CommandExecuted]),
+            });
+
+    private string[] Drain()
+    {
+        lock (_sink)
+        {
+            string[] copy = [.. _sink];
+            _sink.Clear();
+            return copy;
+        }
+    }
+
+    /// <summary>
+    ///     The one statement in <paramref name="logged" />, with parameter names normalized and
+    ///     the timing preamble dropped.
+    /// </summary>
+    private static string SingleStatement(string[] logged)
+    {
+        string entry = Assert.Single(logged);
+
+        // The first two lines are the event header and the `Executed DbCommand (0ms) [...]`
+        // preamble, whose elapsed time and parameter *names* both vary. The statement follows.
+        string[] lines = entry.Split('\n');
+        int start = Array.FindIndex(lines, l => l.TrimStart().StartsWith("SELECT", StringComparison.Ordinal));
+        Assert.True(start >= 0, "no SELECT found in: " + entry);
+
+        string sql = string.Join('\n', lines[start..]).Trim();
+
+        return ParameterName().Replace(sql, "@p");
+    }
+
+    [GeneratedRegex(@"@[A-Za-z_][A-Za-z0-9_]*")]
+    private static partial Regex ParameterName();
+}

--- a/test/InfoCarrier.Core.FunctionalTests/Sqlite/ServerParameterizationTest.cs
+++ b/test/InfoCarrier.Core.FunctionalTests/Sqlite/ServerParameterizationTest.cs
@@ -1,4 +1,4 @@
-// Licensed under the MIT license. See license.txt file in the project root for license information.
+﻿// Licensed under the MIT license. See license.txt file in the project root for license information.
 
 using System.Text.RegularExpressions;
 using InfoCarrier.Core.FunctionalTests.TestUtilities;
@@ -63,6 +63,50 @@ public partial class ServerParameterizationTest
         => AssertSameStatement(
             2,
             static (blogs, take) => blogs.OrderBy(b => b.Id).Skip(1).Take(take));
+
+    /// <summary>
+    ///     A key lookup on a <see cref="Guid" /> key, which is the case a whole-suite sweep found
+    ///     after the scalar one was fixed.
+    /// </summary>
+    /// <remarks>
+    ///     <c>ExpressionExtensions.BuildPredicate</c> builds this as
+    ///     <c>EF.Property&lt;object&gt;(e, "Id") == keyValues[i]</c>, so the parameter's declared
+    ///     type is <c>object</c> and the guard that excluded <c>object</c> excluded every
+    ///     non-numeric key lookup with it — 3,927 of them in the SQLite tier alone, each reaching
+    ///     the store as a literal. `Find` is not an edge case.
+    /// </remarks>
+    [ConditionalFact]
+    public async Task A_Guid_key_lookup_stays_a_parameter()
+    {
+        Guid id = new("11111111-1111-1111-1111-111111111111");
+
+        await using SqliteInfoCarrierBackendTestStore store = CreateStore();
+        await store.InitializeAsync(
+            store.ServiceProvider,
+            store.CreateDbContext,
+            seed: async context =>
+            {
+                context.Add(new GuidKeyed { Id = id, Label = "one" });
+                await context.SaveChangesAsync();
+            });
+
+        Drain();
+
+        await using (SqliteSmokeContext client = new(
+            new DbContextOptionsBuilder<SqliteSmokeContext>().UseInfoCarrier(store).Options))
+        {
+            Assert.NotNull(await client.GuidKeyed.FindAsync(id));
+        }
+
+        string overTheWire = SingleStatement(Drain());
+
+        using (DbContext server = store.CreateDbContext())
+        {
+            Assert.NotNull(await server.Set<GuidKeyed>().FindAsync(id));
+        }
+
+        Assert.Equal(SingleStatement(Drain()), overTheWire);
+    }
 
     /// <summary>
     ///     Runs <paramref name="query" /> over the wire and again directly against the server, and

--- a/test/InfoCarrier.Core.FunctionalTests/TestUtilities/SmokeContext.cs
+++ b/test/InfoCarrier.Core.FunctionalTests/TestUtilities/SmokeContext.cs
@@ -1,4 +1,4 @@
-// Licensed under the MIT license. See license.txt file in the project root for license information.
+﻿// Licensed under the MIT license. See license.txt file in the project root for license information.
 
 using Microsoft.EntityFrameworkCore;
 
@@ -76,4 +76,24 @@ public class SqliteSmokeContext(DbContextOptions<SqliteSmokeContext> options) : 
     public DbSet<Post> Posts => Set<Post>();
 
     public DbSet<Tag> Tags => Set<Tag>();
+
+    public DbSet<GuidKeyed> GuidKeyed => Set<GuidKeyed>();
+}
+
+/// <summary>
+///     An entity with a <see cref="System.Guid" /> key, for
+///     <c>ServerParameterizationTest</c> (issue #59).
+/// </summary>
+/// <remarks>
+///     The key type is the whole point and an <see cref="int" /> will not do.
+///     <c>ExpressionExtensions.BuildPredicate</c> compares a <em>numeric</em> key through
+///     <c>EF.Property&lt;TKey&gt;</c>, and every other key type — a <c>Guid</c> above all —
+///     through <c>EF.Property&lt;object&gt;</c>. Only the second shape produces the
+///     <c>object</c>-typed parameter this exists to pin.
+/// </remarks>
+public class GuidKeyed
+{
+    public Guid Id { get; set; }
+
+    public string? Label { get; set; }
 }

--- a/test/known-failures.txt
+++ b/test/known-failures.txt
@@ -346,5 +346,30 @@
 #
 # `failed` unchanged at 9, FIXED none, BROKEN none, REASONS unchanged.
 # Figures read off the run's own summary block: 22662 / 22476 / 9 / 177 (`cancellation-final`).
+# 22662 -> 22666, four new tests of ours. Issue #59: a scalar query parameter reached the server
+# as a plain `ConstantExpression`, so the backing store saw a SQL *literal* where every other EF
+# client sees a SQL parameter -- one statement and one compiled-query cache entry per distinct
+# value. `QueryExecutor.Substitute` now boxes a wire primitive as well, which is what makes the
+# server's own funcletizer lift it back into a parameter.
+#
+# MEASURED, not reasoned. `ServerParameterizationTest` logs the *server* context's
+# `RelationalEventId.CommandExecuted` through `SharedTestStoreProperties.OnAddOptions`, runs each
+# query twice -- over the wire and directly against the server -- and asserts one statement, not
+# two. Parameter *names* are normalized first: a parameter crosses inside `ParameterBox<T>`, so
+# EF names it after the box's property. `@Value` against `@title` is expected; `'beta'` against
+# `@title` was the defect.
+#
+# PROVED FAILABLE. With the fix stashed, exactly two of the four fail -- the scalar string and the
+# scalar int -- and `Contains` and `Skip`/`Take` still pass. That boundary is the defect's.
+#
+# ONE EXCEPTION, and the first run found it. Boxing every scalar broke
+# `Column_collection_equality_inline_collection_with_parameters`: in `c.Ints == new[] { i, j }`
+# every element became an evaluatable member read, so EF folded the whole array into one
+# parameter and the inline-collection shape was gone. `_insideInlineCollection` keeps a scalar
+# inside a `NewArrayExpression` or `ListInitExpression` a constant. That is research-findings §6's
+# 2026-08-02 amendment seen from the other side.
+#
+# `failed` unchanged at 9, FIXED none, BROKEN none, REASONS unchanged.
+# Figures read off the run's own summary block: 22666 / 22480 / 9 / 177 (`issue59-v2`).
 failed=9
-total=22662
+total=22666

--- a/test/known-failures.txt
+++ b/test/known-failures.txt
@@ -371,5 +371,23 @@
 #
 # `failed` unchanged at 9, FIXED none, BROKEN none, REASONS unchanged.
 # Figures read off the run's own summary block: 22666 / 22480 / 9 / 177 (`issue59-v2`).
+# 22666 -> 22667, a fifth test of ours, and a second half to issue #59 that a whole-suite sweep
+# found after the first half was already green.
+#
+# `ExpressionExtensions.BuildPredicate` builds a key lookup as
+# `EF.Property<object>(e, name) == keyValues[i]` for every key that is a value type and not
+# numeric -- a `Guid` above all. The parameter's declared type is therefore `object`, and J21's
+# `parameterType != typeof(object)` guard excluded it, so `Find()` sent the key as a literal.
+# **3,927 of those in the SQLite tier alone**, counted by instrumenting `Substitute` and running
+# the suite. `Find` is not an edge case; it is the hottest path an application has.
+#
+# THE FIRST FIX WAS WRONG AND THE SUITE SAID SO. Boxing on the declared type alone broke 21
+# `KeysWithConvertersInfoCarrierTest` tests with "Object must implement IConvertible": a
+# `BytesStructKey` is not a wire primitive and `object` had hidden that. The runtime type is read
+# here, which is the one place J19's "decide from the declared type" cannot apply, because `object`
+# is the one declared type that answers nothing.
+#
+# `failed` unchanged at 9, FIXED none, BROKEN none, REASONS unchanged.
+# Figures read off the run's own summary block: 22667 / 22481 / 9 / 177 (`issue59-final`).
 failed=9
-total=22666
+total=22667


### PR DESCRIPTION
Fixes #59.

## What was wrong

`QueryExecutor.Substitute` turned every scalar query parameter into a plain `ConstantExpression`. A constant is not a parameter to EF, so the backing store saw a SQL literal where every other EF client sees a SQL parameter.

Measured on the SQLite tier by logging the **server** context's `RelationalEventId.CommandExecuted`:

| Query | Over the wire, before | Directly on the server |
|---|---|---|
| `Where(b => b.Title == title)` | `WHERE "b"."Title" = 'beta'`, `[Parameters=[]]` | `WHERE "b"."Title" = @title` |
| `Where(b => b.Id >= minId)` | `WHERE "b"."Id" >= 2`, `[Parameters=[]]` | `WHERE "b"."Id" >= @minId` |
| `Where(b => titles.Contains(b.Title))` | `IN (@Value1, @Value2)` | `IN (@titles1, @titles2)` |
| `OrderBy(...).Skip(1).Take(minId)` | `LIMIT @p0 OFFSET @p` | `LIMIT @p0 OFFSET @p` |

Rows 3 and 4 were already correct, which is what made the boundary visible. `ParameterBox<T>` has carried collections since B22; scalars were the gap.

Consequence: one statement and one server-side compiled-query cache entry per distinct value. `ExpressionEqualityComparer.CompareConstant` reads tree constants into that key, which the J21 comment already noted for a different reason.

## The fix

`Substitute` boxes a wire primitive as well. This invents no parameterization: the method is reached only for a node EF's **own** funcletizer already made a parameter on the client, and `EF.Constant` is excluded one level up by `_insideEFCall`. The box restores a decision the wire discarded.

**One exception, and the first full run found it.** A scalar inside an inline collection the caller wrote must stay a constant. In `c.Ints == new[] { i, j }` every element became an evaluatable member read, EF folded the whole array into a single parameter, and `Column_collection_equality_inline_collection_with_parameters` failed. `_insideInlineCollection` is the guard, and it is `research-findings` §6's 2026-08-02 amendment seen from the other side: that one spelled a collection out so relational EF would see the shape, this one declines to take the shape apart.

## The test is differential, not a baseline

`ServerParameterizationTest` runs each query twice, over the wire and directly against the server, and asserts the store saw one statement rather than two. Parameter names are normalized first, because a parameter crosses inside `ParameterBox<T>` and EF names it after the box's property: `@Value` against `@title` is expected, `'beta'` against `@title` was the defect.

Golden SQL strings were deliberately not used. They would pin SQLite's dialect, which EF already tests, and say nothing about the middleman.

Nothing in this suite had ever read the server's SQL. `InfoCarrierTestStoreFactory` builds a `TestSqlLoggerFactory`, but it belongs to the client, which has no database and emits none, and `InfoCarrierBackendTestStore` wires no logger at all. The test uses the `SharedTestStoreProperties.OnAddOptions` hook.

**Proved failable.** With the fix stashed, exactly the scalar string and the scalar int fail; `Contains` and `Skip`/`Take` still pass.

## Gates

- `CI=true dotnet build InfoCarrier.Core.slnx --configuration Release` — 5 Warning(s), 0 Error(s), the documented green.
- `eng/measure.sh issue59-v2 post-release` — **Passed: 22480, Failed: 9, Total: 22666**. FIXED none, BROKEN none, REASONS unchanged.
- `eng/trim-ratchet.sh` — OK (89 <= 89).
- `eng/doc-links.py` — 0 broken in 57 files.

`test/known-failures.txt` moves `total` 22662 → 22666 for the four new tests; `failed` stays 9, so `known-failures.names.txt` is unchanged.

## Second half: `Find()` had the same defect

A layer-1 sweep instrumented `Substitute` and ran the whole suite. It found 4,156 inlined substitutions whose parameter was declared `object` — 3,996 `Guid` and 132 `DateTime`, with 3,927 in the SQLite tier alone.

They are key lookups. `ExpressionExtensions.BuildPredicate` compares a key that is a value type and not numeric through `EF.Property<object>`, so the parameter is declared `object` and J21's guard excluded it. `Find()` was sending the key as a literal.

Boxing on the declared type alone broke 21 `KeysWithConvertersInfoCarrierTest` tests with *"Object must implement IConvertible"*, so boxing is restricted to a wire-primitive runtime type. That reads the runtime type, which is the one place J19's "decide from the declared type" cannot apply, because `object` answers nothing.

## Residual, measured rather than assumed

The same sweep re-run after both fixes:

| Outcome | Before | After |
|---|---|---|
| `boxed:scalar` | 29,515 | 33,650 |
| `inlined:object` | **4,156** | **28** |
| `inlined:inline-collection` | 166 | 166 |
| `inlined:unmapped` | 62 | 62 |
| `inlined:entity` | 56 | 54 |
| `inlined:collection-unboxable` | 51 | 51 |
| `inlined:ef-call` | 18 | 18 |

Inlined substitutions fell from 4,509 to 379. About 130 of the remainder are plausibly the same class and are unexamined — converted struct keys, entity constants, collections the wire cannot rebuild, and complex-type values. They are filed separately rather than left unrecorded.

## What is evidenced, and what is not

**Measured**: the statement text and its parameter list, for three shapes, before and after.

**Inference, and stated as such in #59**: no plan reuse and unbounded cache growth. Those follow from the statement text by reasoning about how a database and EF behave. No plan cache was counted.

The server-side EF compiled-query cache is the strongest of the inferred claims, since EF computes its cache key after funcletization and the measured parameters are downstream of that. The **client** cache was never affected: the defect lived downstream of it, at `IDatabase.CompileQuery`.
