### PR TITLE
Let a failing Tier B test show the SQL the server ran

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -110,6 +110,38 @@ DB per batch. See [`ci-cd.md`](ci-cd.md).
 3. Relationships, owned types, inheritance.
 4. Spatial, advanced queries.
 
+### 5.2 Differential SQL testing, and reading the server's SQL
+
+Added 2026-08-28, after #59 — a defect no test in the suite could see, because the suite compares
+**answers** and the answers were right. A scalar query parameter was reaching the backing store as a
+SQL *literal* where every other EF client sends a SQL parameter.
+
+**The category this suite was missing is not "assert the SQL".** EF's relational bases pin generated
+SQL against golden strings, and those are the backing store's business: they fail when SQLite changes
+its dialect, which EF already tests, and they would fail here for a cosmetic reason as well, since a
+parameter crosses inside `ParameterBox<T>` and EF names it after the box's property.
+
+The category is **differential**:
+
+> Run the query twice — once from the client over the wire, once directly against the server
+> context — capture both statements, and assert they are the same after normalizing parameter names.
+
+That asks the one question this project has and EF does not: *does the middleman change the
+statement?* It needs no golden strings, so it survives an EF version bump, and it fails the moment
+the wire turns a parameter into a literal, reorders a join, or drops an index-friendly predicate.
+`ServerParameterizationTest` is the first of these.
+
+**Reading the server's SQL at all.** `InfoCarrierTestStoreFactory` does build a
+`TestSqlLoggerFactory`, but it belongs to the *client*, which has no database and emits none. Set
+`INFOCARRIER_SERVER_SQL=1` and `InfoCarrierBackendTestStore` writes every server command to
+`server-sql.log` in the test output directory. Off in every normal run, asserts nothing, and exists
+so that a failing Tier B test can be re-run and read rather than reasoned about. `ServerSqlLog`
+records why it is a switch and a file rather than output attached to a failing test.
+
+**What is still missing** is the provenance the harness cannot have: whether a literal in the SQL
+came from a constant the caller wrote or from a parameter this provider inlined. Only
+`QueryExecutor.Substitute` knows, and issue #49 covers shipping that as a diagnostic event.
+
 ### 5.1 EF Core 3.1 → 10 port risks (from v1 study)
 
 | Risk | Detail |

--- a/test/InfoCarrier.Core.FunctionalTests/TestUtilities/InfoCarrierBackendTestStore.cs
+++ b/test/InfoCarrier.Core.FunctionalTests/TestUtilities/InfoCarrierBackendTestStore.cs
@@ -1,4 +1,4 @@
-// Licensed under the MIT license. See license.txt file in the project root for license information.
+﻿// Licensed under the MIT license. See license.txt file in the project root for license information.
 
 using InfoCarrier.Core.Common;
 using Microsoft.EntityFrameworkCore;
@@ -207,6 +207,15 @@ public abstract class InfoCarrierBackendTestStore : TestStore, IInfoCarrierClien
     public override DbContextOptionsBuilder AddProviderOptions(DbContextOptionsBuilder builder)
     {
         builder = builder.UseInternalServiceProvider(ServiceProvider).EnableSensitiveDataLogging();
+
+        // Opt-in, and off in every normal run. See ServerSqlLog for why this is a switch and a
+        // file rather than output attached to a failing test.
+        if (ServerSqlLog.IsEnabled)
+        {
+            builder = builder.LogTo(
+                ServerSqlLog.Write,
+                [Microsoft.EntityFrameworkCore.Diagnostics.RelationalEventId.CommandExecuted]);
+        }
 
         return _testStoreProperties.OnAddOptions?.Invoke(builder) ?? builder;
     }

--- a/test/InfoCarrier.Core.FunctionalTests/TestUtilities/ServerSqlLog.cs
+++ b/test/InfoCarrier.Core.FunctionalTests/TestUtilities/ServerSqlLog.cs
@@ -1,0 +1,71 @@
+// Licensed under the MIT license. See license.txt file in the project root for license information.
+
+namespace InfoCarrier.Core.FunctionalTests.TestUtilities;
+
+/// <summary>
+///     An opt-in record of the SQL the <em>server</em> ran, for diagnosing a failing Tier B test.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>Off unless <c>INFOCARRIER_SERVER_SQL</c> is set, and it asserts nothing.</b> Its
+///         whole job is that a failing test can be re-run with the switch on and the statements
+///         read back. Until #59 there was no way to see them at all:
+///         <see cref="InfoCarrierTestStoreFactory" /> builds a
+///         <c>TestSqlLoggerFactory</c>, but it belongs to the <em>client</em>, which has no
+///         database and emits none, and <see cref="InfoCarrierBackendTestStore" /> wired no logger.
+///     </para>
+///     <para>
+///         <b>Why a file and a switch rather than test output on failure.</b> EF attaches its own
+///         SQL to a failing test through <c>TestSqlLoggerFactory.SetTestOutputHelper</c>, which
+///         every relational base takes an <c>ITestOutputHelper</c> to supply. Reaching that here
+///         would mean threading one through every Tier B test class, and xUnit gives a fixture no
+///         way to know a test failed. A switch costs nothing when off, and the diagnostic loop —
+///         re-run the one failing test with a filter, read the file — is the same loop anyone is
+///         already in.
+///     </para>
+///     <para>
+///         This is diagnosis, not coverage. The test that asserts the server's SQL is
+///         <c>ServerParameterizationTest</c>, and it compares a statement against the same query
+///         run directly rather than against a golden string.
+///     </para>
+/// </remarks>
+public static class ServerSqlLog
+{
+    private static readonly object Gate = new();
+
+    /// <summary>
+    ///     Whether server SQL is being recorded.
+    /// </summary>
+    public static bool IsEnabled { get; }
+        = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("INFOCARRIER_SERVER_SQL"));
+
+    /// <summary>
+    ///     Where the statements are written.
+    /// </summary>
+    /// <remarks>
+    ///     The test output directory, so it sits beside the <c>.db</c> files of the run that
+    ///     produced it. Truncated once per process, on the first write.
+    /// </remarks>
+    public static string Path { get; }
+        = System.IO.Path.Combine(AppContext.BaseDirectory, "server-sql.log");
+
+    private static bool _started;
+
+    /// <summary>
+    ///     Records one statement.
+    /// </summary>
+    /// <param name="line">The formatted log line, as <c>LogTo</c> supplies it.</param>
+    public static void Write(string line)
+    {
+        lock (Gate)
+        {
+            if (!_started)
+            {
+                System.IO.File.WriteAllText(Path, string.Empty);
+                _started = true;
+            }
+
+            System.IO.File.AppendAllText(Path, line + Environment.NewLine + Environment.NewLine);
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #59, and the diagnosis half of what that investigation needed.

## Why

Nothing in this suite could read the server's SQL. `InfoCarrierTestStoreFactory` does build a `TestSqlLoggerFactory`, but it belongs to the **client**, which has no database and emits none, and `InfoCarrierBackendTestStore` wired no logger at all. That is why #59 stood unseen: the suite compares answers, and the answers were right.

## What

`INFOCARRIER_SERVER_SQL=1` makes the backend store write every server command to `server-sql.log` in the test output directory. Off in every normal run, and it **asserts nothing**.

Verified both ways: with the switch unset no file is written; with it set, the statements appear.

A switch and a file rather than output attached to a failing test, because EF's mechanism for that is `TestSqlLoggerFactory.SetTestOutputHelper`, which needs an `ITestOutputHelper` threaded through every Tier B test class, and xUnit gives a fixture no way to know a test failed. The loop this serves — re-run the one failing test with a filter, read the file — is the loop anyone is already in.

`architecture.md` gains §5.2 for the testing category this repository was missing: **differential** SQL testing, which asks whether the middleman changes the statement, as against golden-string baselines, which ask what SQLite emits and are the backing store's business.

## Gates

- `eng/measure.sh` — **Passed: 22481, Failed: 9, Total: 22667**. FIXED none, BROKEN none, REASONS unchanged. Run on identical content while #61 was still open; the tree is byte-identical after replay onto the merged `main`.
- `CI=true dotnet build --configuration Release` — 5 Warning(s), 0 Error(s), the documented green.
- `eng/doc-links.py` 0 broken, `eng/doc-words.py` 0 over budget.
- No `src/` change, so no trim ratchet needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)