### PR TITLE
The 10.0.1 release body

### DIFF
--- a/docs/release-bodies/v10.0.1.md
+++ b/docs/release-bodies/v10.0.1.md
@@ -1,0 +1,18 @@
+This is a patch release with one fix.
+
+- A query parameter reached the database as a SQL literal instead of a SQL parameter, so every distinct value produced a new statement.
+- `Find()` and any lookup on a key that is not numeric sent the key as a literal too.
+- The database can now reuse one plan per query, and the server's compiled-query cache one entry, instead of one of each per value.
+- A scalar parameter now travels wrapped. A `10.0.1` client still works against a `10.0.0` server, because the wrapper was already part of the protocol.
+- No public API changed, and the fix needs no code change.
+- Verified against Microsoft's EF Core specification suite: 22667 tests, 9 known failures, gated in CI.
+
+```sh
+dotnet add package InfoCarrier.Core              # the client and the server
+dotnet add package InfoCarrier.Core.AspNetCore   # the server endpoint
+```
+
+- [What is new in 10.0](https://azabluda.github.io/InfoCarrier.Core/release-notes/10.0/), the full list
+- [Upgrading from 3.1](https://azabluda.github.io/InfoCarrier.Core/getting-started/upgrading-from-3-1/)
+- [Limitations](https://azabluda.github.io/InfoCarrier.Core/limitations/), worth reading before you adopt
+- [Documentation](https://azabluda.github.io/InfoCarrier.Core/)

--- a/website/docs/release-notes/10.0.md
+++ b/website/docs/release-notes/10.0.md
@@ -4,7 +4,8 @@ InfoCarrier.Core 10.0 is a rewrite for Entity Framework Core 10. It shares its n
 with the 1.0 to 3.1 line and almost nothing else: the expression serializer, the wire format, the
 client/server split and the security model are all new code.
 
-The current release of this line is `10.0.0`.
+The current release of this line is `10.0.1`, which fixes a query parameter reaching the database as
+a literal instead of a parameter. Upgrading needs no code change.
 
 ## The expression serializer is in-tree
 


### PR DESCRIPTION
The curated body for the `v10.0.1` tag, which is already pushed and building.

`release.yml` creates the GitHub Release with a placeholder body. The curated one lives in `docs/release-bodies/<tag>.md` and is applied afterwards with `gh release edit`, because GitHub keeps no history of a release body.

## Against `doc-style.md`

- One clause of identity, then six lines, one per major change, then the install command and the links.
- **149 words** against the 150 the rule names.
- No group headings, no bold lead-ins, no dashes. Run through the `humanizer` skill.
- Every link points at a page already deployed from `main`.

## The site page

`website/docs/release-notes/10.0.md` said `10.0.0` was the current release of the line, which is now false. It reads **695 words against a budget of 700**, so the patch note there is one sentence and the news stays in the release body.

That follows the budget rule in `doc-style.md`: cut the padding a reader named before moving the number, and no reader has named any here.

## Gates

- `eng/doc-words.py` — 0 over budget.
- `eng/doc-links.py` — 0 broken in 58 files.
- Docs only. No code, so no measure and no trim ratchet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)