### PR TITLE
Close out #62: breadth for the differential test, and the limitations page

### DIFF
--- a/docs/plans/v10/implementation-plan.md
+++ b/docs/plans/v10/implementation-plan.md
@@ -145,5 +145,14 @@ because the test author wrote the query.
       `website/docs/limitations.md` needs the query added to its "answers where others refuse"
       section. `failed` 12 -> 11. 22674 / 22486 / 11 / 177 (`issue62-fix-complex-full`). Trim
       ratchet 89 <= 89.
-- [ ] **S7. `limitations.md`: one more query this provider answers and other providers refuse.**
-      User-facing, so the humanizer skill runs on the result before it lands.
+- [x] **S7. `limitations.md`: one more query this provider answers and other providers refuse.**
+      User-facing, so the humanizer skill ran on the result. The section says three scenarios rather
+      than two. The page was ten words over its 700-word budget once the third was added, so the
+      pass had to earn them back; it measures 698 and `doc-links.py` passes with anchors.
+- [x] **S8. Eight cases pinning where the wire could change the statement's shape.** #62's four
+      categories were all found by counting substitutions, and a count only finds a value that was
+      already inlined. These come from the other direction: four on the comparison (a null string, a
+      `StartsWith` argument, an empty `Contains` list, a value in the projection) and four on
+      structure (`Include`, `GroupBy`, `Any` over a navigation, a nullable value type). **All eight
+      passed on the first run**, which is the result rather than a disappointment: eight assumptions
+      became eight assertions. `failed` unchanged at 11, `total` 22674 -> 22682.

--- a/test/InfoCarrier.Core.FunctionalTests/Sqlite/ServerParameterizationTest.cs
+++ b/test/InfoCarrier.Core.FunctionalTests/Sqlite/ServerParameterizationTest.cs
@@ -111,6 +111,90 @@ public partial class ServerParameterizationTest
     }
 
     /// <summary>
+    ///     Four cases where a <em>constant</em> and a <em>parameter</em> do not merely differ in
+    ///     the literal: they make EF translate the query differently.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The cases above all began as an inlined value that should have been a parameter, and
+    ///         each was found by counting substitutions. These four come from the other direction:
+    ///         ask where the wire could plausibly change the <em>shape</em> of the statement, and
+    ///         pin those places whether or not a defect is there today.
+    ///     </para>
+    ///     <para>
+    ///         A null, a <c>StartsWith</c> argument, an empty <c>Contains</c> list and a value in
+    ///         the projection are the four EF handles specially. A null compiles to <c>IS NULL</c>
+    ///         when EF can see it and to a null-semantics expansion when it cannot; a
+    ///         <c>StartsWith</c> constant can become a plain <c>LIKE 'x%'</c> where a parameter
+    ///         cannot; an empty list is a constant-folded predicate; and a projected value is the
+    ///         one place a parameter appears outside a predicate.
+    ///     </para>
+    /// </remarks>
+    [ConditionalFact]
+    public Task A_null_string_parameter_matches_the_direct_query()
+        => AssertSameStatement<string?, Blog>(
+            null,
+            static (blogs, title) => blogs.Where(b => b.Title == title));
+
+    /// <inheritdoc cref="A_null_string_parameter_matches_the_direct_query" />
+    [ConditionalFact]
+    public Task A_StartsWith_parameter_matches_the_direct_query()
+        => AssertSameStatement<string, Blog>(
+            "al",
+            static (blogs, prefix) => blogs.Where(b => b.Title!.StartsWith(prefix)));
+
+    /// <inheritdoc cref="A_null_string_parameter_matches_the_direct_query" />
+    [ConditionalFact]
+    public Task An_empty_collection_parameter_matches_the_direct_query()
+        => AssertSameStatement<List<string>, Blog>(
+            [],
+            static (blogs, titles) => blogs.Where(b => titles.Contains(b.Title!)));
+
+    /// <inheritdoc cref="A_null_string_parameter_matches_the_direct_query" />
+    [ConditionalFact]
+    public Task A_parameter_in_the_projection_matches_the_direct_query()
+        => AssertSameStatement<string, string>(
+            "!",
+            static (blogs, suffix) => blogs.Select(b => b.Title + suffix));
+
+    /// <summary>
+    ///     Four more, where the parameter sits inside a construct that changes the statement's
+    ///     structure rather than one of its comparisons.
+    /// </summary>
+    /// <remarks>
+    ///     An <c>Include</c> is a join, a <c>GroupBy</c> is a <c>GROUP BY</c>, an <c>Any</c> over a
+    ///     navigation is a correlated <c>EXISTS</c>, and a nullable value type is the shape J19's
+    ///     null rule is about. Each is a place where a middleman that mishandled the parameter
+    ///     would show up as a different statement rather than a different literal.
+    /// </remarks>
+    [ConditionalFact]
+    public Task A_parameter_under_Include_matches_the_direct_query()
+        => AssertSameStatement<string, Blog>(
+            "beta",
+            static (blogs, title) => blogs.Include(b => b.Posts).Where(b => b.Title == title));
+
+    /// <inheritdoc cref="A_parameter_under_Include_matches_the_direct_query" />
+    [ConditionalFact]
+    public Task A_parameter_under_GroupBy_matches_the_direct_query()
+        => AssertSameStatement<int, string?>(
+            2,
+            static (blogs, minId) => blogs.Where(b => b.Id >= minId).GroupBy(b => b.Title).Select(g => g.Key));
+
+    /// <inheritdoc cref="A_parameter_under_Include_matches_the_direct_query" />
+    [ConditionalFact]
+    public Task A_parameter_inside_Any_matches_the_direct_query()
+        => AssertSameStatement<string, Blog>(
+            "first",
+            static (blogs, heading) => blogs.Where(b => b.Posts.Any(p => p.Heading == heading)));
+
+    /// <inheritdoc cref="A_parameter_under_Include_matches_the_direct_query" />
+    [ConditionalFact]
+    public Task A_nullable_value_type_parameter_matches_the_direct_query()
+        => AssertSameStatement<int?, Blog>(
+            2,
+            static (blogs, id) => blogs.Where(b => b.Id == id));
+
+    /// <summary>
     ///     A collection the box cannot hand back, category 3 of issue #62.
     /// </summary>
     /// <remarks>
@@ -250,9 +334,9 @@ public partial class ServerParameterizationTest
     ///     Runs <paramref name="query" /> over the wire and again directly against the server, and
     ///     asserts the store saw one statement, not two.
     /// </summary>
-    private async Task AssertSameStatement<TValue>(
+    private async Task AssertSameStatement<TValue, TResult>(
         TValue value,
-        Func<IQueryable<Blog>, TValue, IQueryable<Blog>> query)
+        Func<IQueryable<Blog>, TValue, IQueryable<TResult>> query)
     {
         await using SqliteInfoCarrierBackendTestStore store = CreateStore();
         await store.InitializeAsync(

--- a/test/known-failures.txt
+++ b/test/known-failures.txt
@@ -567,5 +567,23 @@
 # FIXED the complex value case, BROKEN none.
 # Figures read off the run's own summary block: 22674 / 22486 / 11 / 177
 # (`issue62-fix-complex-full`). Trim ratchet: OURS 89 <= 89, unchanged.
+# 2026-08-28, issue #62, breadth. `failed` unchanged at 11, `total` 22674 -> 22682. Eight NEW tests
+# and all eight green, so the rise is coverage and not a regression.
+#
+# The four categories #62 lists were all found by counting substitutions, which only ever finds a
+# value that was inlined. These eight come from the other direction: ask where the wire could
+# change the SHAPE of the statement, and pin those places whether or not a defect is there today.
+#
+# Four on the comparison — a null string, a `StartsWith` argument, an empty `Contains` list, and a
+# value used in the projection. Four on the statement's structure — a parameter under `Include`,
+# under `GroupBy`, inside `Any` over a navigation, and a nullable value type. Each is a place where
+# EF translates a constant and a parameter differently, so a middleman that mishandled one would
+# show up as a different statement rather than a different literal.
+#
+# **All eight passed on the first run, and that is the result, not a disappointment.** It says the
+# remaining risk in this area is low, and it converts eight assumptions into eight assertions.
+#
+# FIXED none, BROKEN none, REASONS unchanged.
+# Figures read off the run's own summary block: 22682 / 22494 / 11 / 177 (`issue62-breadth`).
 failed=11
-total=22674
+total=22682

--- a/website/docs/limitations.md
+++ b/website/docs/limitations.md
@@ -136,9 +136,9 @@ EF Core provider.
 
 ### Queries this provider answers that other providers reject
 
-Two scenarios in EF's suite assert that a provider rejects the query, and this provider answers
-them correctly instead. A test suite you port from another provider will expect an exception here,
-and LINQ that relies on this leniency will not run unchanged on a relational provider.
+Three scenarios in EF's suite assert that a provider rejects the query. This provider answers them.
+A test suite you port from another provider will expect an exception, and LINQ that relies on this
+will not run unchanged there.
 
 Composing LINQ over a collection stored through a value converter:
 
@@ -168,6 +168,21 @@ modelBuilder.Entity<User>()
 
 var role = Role.Seller;
 context.Users.Where(u => u.Roles.Contains(role)).ToList();
+// EF Core providers: throws.   This provider: returns the matching rows.
+```
+
+Filtering a complex collection, then `Contains`:
+
+```csharp
+modelBuilder.Entity<RootEntity>()
+    .ComplexCollection(e => e.AssociateCollection);   // stored by table splitting
+
+var associates = LoadAssociates();
+context.RootEntities
+    .Where(e => e.AssociateCollection
+        .Where(a => a.Id > associates[0].Id)
+        .Contains(associates[1]))
+    .ToList();
 // EF Core providers: throws.   This provider: returns the matching rows.
 ```
 


### PR DESCRIPTION
Closes #62.

The four categories are checked and fixed (#65 and the two commits before it). This is what was left: breadth for the method that found them, and the consumer-facing statement of what changed.

### `267ead2` — eight cases pinning the statement's shape

Every one of #62's four categories was found by counting substitutions, and a count only ever finds a value that was **already** inlined. These eight come from the other direction: ask where EF translates a constant and a parameter *differently*, and pin those places whether or not a defect is there today.

Four on the comparison itself — a null string, a `StartsWith` argument, an empty `Contains` list, and a value used in the projection. Four on the statement's structure — a parameter under `Include`, under `GroupBy`, inside `Any` over a navigation, and a nullable value type.

**All eight passed on the first run.** That is the result rather than a disappointment: the remaining risk in this area is low, and eight assumptions are now eight assertions. `ServerParameterizationTest` goes from 11 cases to 19.

`AssertSameStatement` is now generic in its result type so a projection case can share the helper.

### `6e75459` — `limitations.md` says three, not two

#65 uncovered a query this provider answers and EF's relational providers reject: filtering a complex collection and then testing it with `Contains`. EF states its own exception is correct there, because the nested collections are null under table splitting. Once a complex value crosses as a parameter rather than as inlined literals, the query translates here and the spec base's own assertion passes.

The humanizer pass ran, as `doc-style.md` requires for anything user facing. It also had to earn ten words: the third scenario put the page at 710 against a 700 budget. It measures **698**, and `doc-links.py` passes including anchors.

### Gates

`22682 / 22494 / 11 / 177` (`issue62-breadth`). FIXED none, BROKEN none, REASONS unchanged. The total rises by eight because eight tests were added and all eight are green.

No `src/` change, so the trim ratchet does not apply.

### Where #62 ends up

All four categories checked, all four fixed, and the tail is no longer "unexamined". What stays inlined is inlined by design and #62's own text says why: an inline collection the caller wrote, `EF.Constant`, and values a query cannot parameterize at all.