### PR TITLE
Point the R20 decimal-divergence notes at issue #75

### DIFF
--- a/docs/plans/v10/implementation-plan.md
+++ b/docs/plans/v10/implementation-plan.md
@@ -346,8 +346,8 @@ only a fraction of what it hid.
       the trailing digits. The `(decimal)` cast over an `int`/`float` `Average`/`Sum` picks a
       different translation on each side of the wire — EF's expected is the `double` computation,
       the server's is SQLite's decimal accumulator, and `AssertEqual` compares exactly. B4 family;
-      left failing per ADR-004, recorded in `test/known-failures.txt`, needs a GitHub issue (PR #74
-      notes the session could not file one). `failed` 72 → 78, `total` unchanged 27021.
+      left failing per ADR-004, recorded in `test/known-failures.txt`, tracked as issue #75.
+      `failed` 72 → 78, `total` unchanged 27021.
 
 ## Phase S — the query parameters still inlined as SQL literals (#62)
 

--- a/test/known-failures.txt
+++ b/test/known-failures.txt
@@ -1146,7 +1146,7 @@
 # returns the accurate value, which QueryAsserter.AssertEqual then rejects for not matching
 # exactly. This is the B4 family in CLAUDE.md -- a type mapping computed twice, once per provider,
 # and the two disagree on which aggregate translation the cast selects. Left failing per ADR-004;
-# no GitHub issue filed yet (the session could not create one -- see PR #74).
+# tracked as issue #75.
 #
 # BROKEN 6 (the three above, sync+async), FIXED none. Figures read off the CI Spec ratchet's TRX:
 # 27021 / 26708 / 78 / 235.


### PR DESCRIPTION
Follow-up to #74. The R20 notes in `test/known-failures.txt` and `docs/plans/v10/implementation-plan.md` said no issue had been filed for the `(decimal)`-cast aggregate divergence. #75 now tracks it — update both pointers.

Docs / baseline-comment only; no test or `src/` change. Closes the loose end noted in #74.