### PR TITLE
Step R21: three Northwind query bases onto their relational bases (#56)

### DIFF
--- a/docs/plans/v10/implementation-plan.md
+++ b/docs/plans/v10/implementation-plan.md
@@ -347,7 +347,37 @@ only a fraction of what it hid.
       different translation on each side of the wire — EF's expected is the `double` computation,
       the server's is SQLite's decimal accumulator, and `AssertEqual` compares exactly. B4 family;
       left failing per ADR-004, recorded in `test/known-failures.txt`, tracked as issue #75.
-      `failed` 72 → 78, `total` unchanged 27021.
+      `failed` 72 → 78, `total` unchanged 27021. (Issue #75 later closed those six — SQLite
+      version and store seeding, not the wire; see `test/known-failures.txt` `#77` block.)
+
+- [x] **R21. Three more Northwind query bases onto their relational bases.** `NorthwindWhere`,
+      `NorthwindJoin` and `NorthwindSelect` — the Northwind query Sqlite classes R18 and R20 did
+      not take. None has a Tier A counterpart, so this is not a tier move: each already ran on
+      Tier B against the *core* base and is re-parented onto the `*RelationalTestBase`, which swaps
+      in `RelationalQueryAsserter` (the fixture has implemented `ITestSqlLoggerFactory` since R18)
+      and folds in that base's expected-answer corrections. None of the three relational bases adds
+      an `AsSplitQuery` route, a `UseTransaction` route or a `RelationalTestStore` cast, so none is
+      gated on #60 or ADR-013. `test/` only, so the gate is `eng/measure.sh`.
+      **Join**: the relational base adds no test and no override — a pure asserter swap. 132 → 132,
+      all green.
+      **Where**: the relational base adds one theory,
+      `EF_MultipleParameters_with_non_evaluatable_argument_throws` (+2, sync and async), which
+      passes, and turns `Where_bool_client_side_negated` into `AssertTranslationFailed` — this
+      provider fails that translation identically, so the hand-written override that used to
+      restate it is deleted and inherited instead. 406 → 408, all green.
+      **Select**: `Reverse_without_explicit_ordering` was restated by hand here with a comment
+      that the class "cannot derive from" the relational base; it now can, so the restatement is
+      deleted and inherited. The base also turns
+      `Select_bool_closure_with_order_by_property_with_cast_to_nullable` into
+      `AssertTranslationFailed` — and **this provider answers that query** (its split evaluates the
+      `OrderBy` over a client constant projection and the server runs the rest), so the inherited
+      assertion is overridden back to the core answer-check, which passes. Same category as
+      `limitations.md`'s "queries this provider answers that other EF providers refuse". 372 → 372,
+      all green.
+      `failed` unchanged at 72, `total` 27021 → 27023, FIXED none, BROKEN none. The three relational
+      bases leave `InfoCarrierComplianceTest`'s missing list at 101 (was 104). Measured with local
+      per-class runs (`--filter`); a full run OOMs this box, so the CI Spec ratchet confirms the
+      figures.
 
 ## Phase S — the query parameters still inlined as SQL literals (#62)
 

--- a/test/InfoCarrier.Core.FunctionalTests/Sqlite/Query/NorthwindJoinQuerySqliteInfoCarrierTest.cs
+++ b/test/InfoCarrier.Core.FunctionalTests/Sqlite/Query/NorthwindJoinQuerySqliteInfoCarrierTest.cs
@@ -13,16 +13,18 @@ using Xunit;
 namespace InfoCarrier.Core.FunctionalTests.Sqlite.Query;
 
 /// <summary>
-///     <see cref="NorthwindJoinQueryTestBase{TFixture}" /> on ADR-009 Tier B (SQLite).
+///     <see cref="NorthwindJoinQueryRelationalTestBase{TFixture}" /> on ADR-009 Tier B (SQLite).
 /// </summary>
 /// <remarks>
-///     Overrides only for what a run actually showed. Whether the Tier A class's overrides still apply on a backend that
-///     genuinely translates is a question this class answers by measurement; overrides are added
-///     only for what a run actually shows, with the reason stated. Red here is information
-///     (CLAUDE.md), not a regression.
+///     Derives from the <em>relational</em> base (#56), not the core one. The relational base only
+///     swaps in <c>RelationalQueryAsserter</c> — it adds no test the core base lacks — so the
+///     bare move changes no count; it exists to pick up the relational base's expected-answer
+///     corrections as EF adds them, the same reason R18 and R20 took the other Northwind bases.
+///     Overrides only for what a run actually showed. Red here is information (CLAUDE.md), not a
+///     regression.
 /// </remarks>
 public class NorthwindJoinQuerySqliteInfoCarrierTest(NorthwindQueryInfoCarrierSqliteFixture<NoopModelCustomizer> fixture)
-    : NorthwindJoinQueryTestBase<NorthwindQueryInfoCarrierSqliteFixture<NoopModelCustomizer>>(fixture)
+    : NorthwindJoinQueryRelationalTestBase<NorthwindQueryInfoCarrierSqliteFixture<NoopModelCustomizer>>(fixture)
 {
     // -------------------------------------------------------------------------------------
     // BACKING-STORE LIMITATION — SQLite has no APPLY, and a correlated collection projection

--- a/test/InfoCarrier.Core.FunctionalTests/Sqlite/Query/NorthwindSelectQuerySqliteInfoCarrierTest.cs
+++ b/test/InfoCarrier.Core.FunctionalTests/Sqlite/Query/NorthwindSelectQuerySqliteInfoCarrierTest.cs
@@ -1,9 +1,9 @@
 // Licensed under the MIT license. See license.txt file in the project root for license information.
 
 using InfoCarrier.Core.FunctionalTests.TestUtilities;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Sqlite.Internal;
+using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
@@ -14,16 +14,20 @@ using Xunit;
 namespace InfoCarrier.Core.FunctionalTests.Sqlite.Query;
 
 /// <summary>
-///     <see cref="NorthwindSelectQueryTestBase{TFixture}" /> on ADR-009 Tier B (SQLite).
+///     <see cref="NorthwindSelectQueryRelationalTestBase{TFixture}" /> on ADR-009 Tier B (SQLite).
 /// </summary>
 /// <remarks>
-///     Overrides only for what a run actually showed. Whether the Tier A class's overrides still apply on a backend that
-///     genuinely translates is a question this class answers by measurement; overrides are added
-///     only for what a run actually shows, with the reason stated. Red here is information
+///     Derives from the <em>relational</em> base (#56), not the core one. That base swaps in
+///     <c>RelationalQueryAsserter</c> and turns two core tests into translation-failure
+///     assertions — <c>Reverse_without_explicit_ordering</c> (which this class used to restate by
+///     hand, with a comment that it "cannot derive from" the relational base; it now can, because
+///     the fixture implements <c>ITestSqlLoggerFactory</c> since R18) and
+///     <c>Select_bool_closure_with_order_by_property_with_cast_to_nullable</c>. It adds no test the
+///     core base lacks. Overrides only for what a run actually showed. Red here is information
 ///     (CLAUDE.md), not a regression.
 /// </remarks>
 public class NorthwindSelectQuerySqliteInfoCarrierTest(NorthwindQueryInfoCarrierSqliteFixture<NoopModelCustomizer> fixture)
-    : NorthwindSelectQueryTestBase<NorthwindQueryInfoCarrierSqliteFixture<NoopModelCustomizer>>(fixture)
+    : NorthwindSelectQueryRelationalTestBase<NorthwindQueryInfoCarrierSqliteFixture<NoopModelCustomizer>>(fixture)
 {
     // -------------------------------------------------------------------------------------
     // BACKING-STORE LIMITATION — SQLite has no APPLY, and a correlated collection projection
@@ -153,14 +157,8 @@ public class NorthwindSelectQuerySqliteInfoCarrierTest(NorthwindQueryInfoCarrier
     // the same backend, adopted verbatim now that the split ships the whole query.
     // -------------------------------------------------------------------------------------
 
-    // `Reverse` with nothing to reverse: SQL has no row order to invert. Every relational
-    // provider fails this, so EF puts the override on NorthwindSelectQueryRelationalTestBase --
-    // a base this class cannot derive from, because it also swaps in a RelationalQueryAsserter
-    // that needs relational test infrastructure. The assertion is the one that base makes.
-    public override Task Reverse_without_explicit_ordering(bool async)
-        => AssertTranslationFailedWithDetails(
-            () => base.Reverse_without_explicit_ordering(async),
-            RelationalStrings.MissingOrderingInSelectExpression);
+    // `Reverse` with nothing to reverse (Reverse_without_explicit_ordering) is now inherited
+    // from NorthwindSelectQueryRelationalTestBase, which asserts exactly this failure.
 
     // EF's NorthwindSelectQuerySqliteTest asserts exactly this failure for exactly this test.
     public override Task
@@ -170,4 +168,23 @@ public class NorthwindSelectQuerySqliteInfoCarrierTest(NorthwindQueryInfoCarrier
             () => base
                 .SelectMany_with_collection_being_correlated_subquery_which_references_non_mapped_properties_from_inner_and_outer_entity(
                     async));
+
+    // -------------------------------------------------------------------------------------
+    // THIS PROVIDER ANSWERS A QUERY EF's RELATIONAL PROVIDERS REJECT.
+    // NorthwindSelectQueryRelationalTestBase turns this into AssertTranslationFailed: a
+    // relational provider cannot ORDER BY a client-side constant projection. This provider's
+    // split evaluates the ordering over the constant on the client (it is a no-op over a single
+    // distinct value) and the server runs the rest, so the query returns the correct rows.
+    // Restored to the core assertion — the answer is checked, and it is right. Same category as
+    // limitations.md's "queries this provider answers that other EF providers refuse".
+    // -------------------------------------------------------------------------------------
+    public override async Task Select_bool_closure_with_order_by_property_with_cast_to_nullable(bool async)
+    {
+        var boolean = false;
+
+        await AssertQuery(
+            async,
+            ss => ss.Set<Customer>().Select(c => new { f = boolean }).OrderBy(e => (bool?)e.f),
+            assertOrder: true);
+    }
 }

--- a/test/InfoCarrier.Core.FunctionalTests/Sqlite/Query/NorthwindWhereQuerySqliteInfoCarrierTest.cs
+++ b/test/InfoCarrier.Core.FunctionalTests/Sqlite/Query/NorthwindWhereQuerySqliteInfoCarrierTest.cs
@@ -7,24 +7,24 @@ using Microsoft.EntityFrameworkCore.TestUtilities;
 namespace InfoCarrier.Core.FunctionalTests.Sqlite.Query;
 
 /// <summary>
-///     The same inherited base as <see cref="NorthwindWhereQueryInfoCarrierTest" />, on ADR-009
-///     Tier B (SQLite).
+///     <see cref="NorthwindWhereQueryRelationalTestBase{TFixture}" /> on ADR-009 Tier B (SQLite).
 /// </summary>
 /// <remarks>
 ///     <para>
-///         Deliberately <strong>no overrides</strong>. The Tier A class carries eight, each
-///         asserting a limitation of the backing store or of EF itself; whether they still apply
-///         on a backend that genuinely translates is a question, not an assumption, and this
-///         class is how it gets answered. Overrides are added here only for what this run
-///         actually shows, with the reason stated.
+///         Derives from the <em>relational</em> base (#56), not the core one. The relational base
+///         adds one test the core base lacks —
+///         <c>EF_MultipleParameters_with_non_evaluatable_argument_throws</c> (+2, sync and async)
+///         — swaps in <c>RelationalQueryAsserter</c>, and turns
+///         <c>Where_bool_client_side_negated</c> into an <c>AssertTranslationFailed</c>, which is
+///         why that override is no longer declared here: it is inherited.
 ///     </para>
 ///     <para>
-///         The first run of this class is therefore expected to be red, and is information rather
-///         than a regression (CLAUDE.md).
+///         The other overrides below are this provider's own, added only for what a run actually
+///         showed. Red here is information (CLAUDE.md), not a regression.
 ///     </para>
 /// </remarks>
 public class NorthwindWhereQuerySqliteInfoCarrierTest(NorthwindQueryInfoCarrierSqliteFixture<NoopModelCustomizer> fixture)
-    : NorthwindWhereQueryTestBase<NorthwindQueryInfoCarrierSqliteFixture<NoopModelCustomizer>>(fixture)
+    : NorthwindWhereQueryRelationalTestBase<NorthwindQueryInfoCarrierSqliteFixture<NoopModelCustomizer>>(fixture)
 {
     // -------------------------------------------------------------------------------------
     // UPSTREAM EF CORE LIMITATION — anonymous-type / tuple structural equality against a
@@ -64,9 +64,4 @@ public class NorthwindWhereQuerySqliteInfoCarrierTest(NorthwindQueryInfoCarrierS
 
     public override Task Where_compare_tuple_create_constructed_multi_value_not_equal(bool async)
         => AssertTranslationFailed(() => base.Where_compare_tuple_create_constructed_multi_value_not_equal(async));
-
-    // Client evaluation outside the final projection, as on Tier A. EF Core's own
-    // NorthwindWhereQueryRelationalTestBase overrides this identically.
-    public override Task Where_bool_client_side_negated(bool async)
-        => AssertTranslationFailed(() => base.Where_bool_client_side_negated(async));
 }

--- a/test/known-failures.txt
+++ b/test/known-failures.txt
@@ -1175,5 +1175,32 @@
 #     `UPDATE "OrderDetails" SET "Discount" = round("Discount", 2)` after seeding.
 #
 # FIXED 6, BROKEN none. Figures read off the CI Spec ratchet's TRX: 27021 / 26714 / 72 / 235.
+#
+# 2026-08-30, #56, Phase R21. `failed` UNCHANGED at 72, `total` 27021 -> 27023. Three Northwind
+# query Sqlite classes -- NorthwindWhere, NorthwindJoin, NorthwindSelect -- re-parented from the
+# core *QueryTestBase onto the *QueryRelationalTestBase, the same move R18 and R20 made for the
+# other Northwind query bases. Not a tier move: none of the three has a Tier A counterpart, so
+# each already ran on Tier B; the relational base just swaps in RelationalQueryAsserter (the
+# fixture has implemented ITestSqlLoggerFactory since R18) and folds in expected-answer overrides.
+#
+# The +2 is the one theory NorthwindWhereQueryRelationalTestBase adds that the core base lacks,
+# EF_MultipleParameters_with_non_evaluatable_argument_throws (sync+async), which passes. Join and
+# Select add no test.
+#
+# No new failure. Two inherited AssertTranslationFailed overrides needed handling:
+#   * Where_bool_client_side_negated -- this provider fails the translation identically, so the
+#     hand-written restatement in NorthwindWhereQuerySqliteInfoCarrierTest is deleted and the
+#     relational base's is inherited.
+#   * Select_bool_closure_with_order_by_property_with_cast_to_nullable -- this provider ANSWERS
+#     this query (ORDER BY over a client-constant projection: the split evaluates the ordering on
+#     the client, the server runs the rest), where EF's relational providers refuse to translate
+#     it. Overridden back to the core answer-check in NorthwindSelectQuerySqliteInfoCarrierTest;
+#     same category as limitations.md's "queries this provider answers that other providers
+#     refuse". Reverse_without_explicit_ordering, previously restated by hand in the Select class
+#     with a "cannot derive from the relational base" comment, is now inherited.
+#
+# FIXED none, BROKEN none. Measured with local per-class --filter runs (Join 132/132, Where
+# 406->408, Select 372/372); a full run OOMs this box, so the CI Spec ratchet confirms the
+# figures. known-failures.names.txt is unchanged (no failure added or removed).
 failed=72
-total=27021
+total=27023


### PR DESCRIPTION
Continues R18/R20. Re-parents `NorthwindWhereQuerySqliteInfoCarrierTest`,
`NorthwindJoinQuerySqliteInfoCarrierTest` and `NorthwindSelectQuerySqliteInfoCarrierTest`
from the core `*QueryTestBase` onto `*QueryRelationalTestBase`.

None of the three has a Tier A (InMemory) counterpart, so this is **not** a tier move —
each already ran on Tier B against the core base. The relational base swaps in
`RelationalQueryAsserter` (the fixture has implemented `ITestSqlLoggerFactory` since R18)
and folds in that base's expected-answer overrides. None of the three relational bases
adds an `AsSplitQuery` route, a `UseTransaction` route or a `RelationalTestStore` cast,
so none is gated on #60 or ADR-013. `test/`-only.

### Per class (local `--filter` runs; a full run OOMs the dev box)

| Class | Before | After | Notes |
|---|---|---|---|
| Join | 132/132 | 132/132 | pure asserter swap, no test added, no override |
| Where | 406/406 | 408/408 | +2 = `EF_MultipleParameters_with_non_evaluatable_argument_throws` (passes). Hand-written `Where_bool_client_side_negated` restatement deleted — inherited (this provider fails that translation identically). |
| Select | 372/372 | 372/372 | `Reverse_without_explicit_ordering` restatement deleted — inherited. `Select_bool_closure_with_order_by_property_with_cast_to_nullable` overridden back to the core answer-check: this provider **answers** that query where EF's relational providers refuse to translate it (same category as `limitations.md`). |

### Baseline

`failed` unchanged at **72**, `total` 27021 → **27023** (the +2 above). FIXED none, BROKEN none.
`test/known-failures.txt` updated; `known-failures.names.txt` unchanged (no failure added or removed).
`InfoCarrierComplianceTest`'s missing-base list goes 104 → 101.

**CI Spec ratchet is the authority on the figures** — the local runs above are per-class only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)