### PR TITLE
Step R27/R27a: OwnedTableSplitting, a new Associations family (#56)

### DIFF
--- a/docs/plans/v10/implementation-plan.md
+++ b/docs/plans/v10/implementation-plan.md
@@ -535,6 +535,34 @@ unreachable on a client with no database. Each of our fixtures overrides it with
       the `Projection` and `Collection` ones, *"Unable to translate a collection subquery"* for
       `SetOperations`. R26a is the override subset.
 
+- [x] **R26a. The `OwnedNavigations` override subset — 8 of 8 answered, all from EF's own SQLite
+      suite.** `Passed: 336, Failed: 0, Total: 336` across all three Associations families,
+      identical to the figure before R25 and after it, so `failed` and `total` are both unchanged
+      and the baseline files do not move. Compliance missing 88 → 82, fixtures 22 → 21.
+      Adopted, and why each matched by reason first (A63):
+      • `OwnedNavigationsCollectionSqliteTest.Distinct_projected`, whole, including the
+      `TrackAll` arm EF short-circuits with *"Base test expects 'can't track owned entities'
+      exception, but with SQLite we get 'no CROSS APPLY'"* — which is exactly what R26 measured.
+      • `OwnedNavigationsSetOperationsSqliteTest.Over_associate_collection_projected`, **verbatim,
+      and this is the clearest single thing the re-parent bought.** EF writes it as
+      `Assert.ThrowsAsync<EqualException>` because the relational base asserts
+      `InsufficientInformationToIdentifyElementOfCollectionJoin` and SQLite raises APPLY instead,
+      so the nested assertion failure *is* the statement. C57 could not write it that way — the
+      class then sat on the core base, which makes no assertion to fail — and asserted the APPLY
+      message directly with a paragraph explaining the divergence. That paragraph is now deleted.
+      • The two `Projection.Select_subquery_*_related_FirstOrDefault` from
+      `OwnedJsonProjectionSqliteTest`, character for character. **EF ships no
+      `OwnedNavigationsProjectionSqliteTest` at all** — the whole class is commented out upstream
+      for EF issue #26708 — so there is nothing to adopt there and `OwnedJson`'s is the nearest
+      statement of the same limit, as C20 and C57 already found.
+      **Deliberately not adopted:** `OwnedNavigationsStructuralEqualitySqliteTest` overrides
+      several tests purely to assert golden SQL. Those pass here on the relational base's own
+      assertion, and the golden SQL is the *backing store's* statement text, which this client
+      never emits — taking them would assert nothing and would couple the file to SQLite's
+      formatting. **This is the one place the family does carry golden SQL, and it is in EF's
+      SQLite classes, never in the 35 relational bases** (verified: every `AssertSql` in those 35
+      is the declaration or an empty call).
+
 ## Phase S — the query parameters still inlined as SQL literals (#62)
 
 **Not a milestone.** #59 fixed two shapes of one defect and a sweep counted what survived: 379

--- a/docs/plans/v10/implementation-plan.md
+++ b/docs/plans/v10/implementation-plan.md
@@ -518,6 +518,23 @@ unreachable on a client with no database. Each of our fixtures overrides it with
       after, and `Passed: 109, Failed: 0, Total: 109` for `Navigations` alone. `failed` and
       `total` both unchanged; compliance missing 95 → 88, fixtures 23 → 22. `test/` only.
 
+- [x] **R26. The six `OwnedNavigations` bases, adopted bare — 8 red of 91, and all 8 are one
+      reason.** The fixture re-parents onto `OwnedNavigationsRelationalFixtureBase` and the six
+      classes onto `OwnedNavigations*RelationalTestBase`, with **every override removed** so that
+      the failures are measured before anything is written to answer them.
+      **The hand copy C0 left behind was not complete, which is the argument for the re-parent
+      rather than for maintaining it.** C0 mirrored `OwnedTableSplittingRelationalFixtureBase`'s
+      and `OwnedNavigationsRelationalFixtureBase`'s `ToTable` calls and `AreCollectionsOrdered`;
+      it did not mirror the base's `ValueGeneratedNever()` on every owned key, nor its
+      `Navigation(…).IsRequired()` statements. The re-parent brings both in.
+      `Passed: 83, Failed: 8, Total: 91`, measured locally with a `--filter` run. **The eight are
+      four tests times two `QueryTrackingBehavior` arms, and the reason is the same in all eight:
+      SQLite has no `APPLY`.** Two shapes, which is the reasons diff and not the count:
+      `NoTracking` raises `SqliteStrings.ApplyNotSupported` bare, while `TrackAll` reaches an
+      assertion expecting a different message — *"A tracking query is attempting to project"* for
+      the `Projection` and `Collection` ones, *"Unable to translate a collection subquery"* for
+      `SetOperations`. R26a is the override subset.
+
 ## Phase S — the query parameters still inlined as SQL literals (#62)
 
 **Not a milestone.** #59 fixed two shapes of one defect and a sweep counted what survived: 379

--- a/docs/plans/v10/implementation-plan.md
+++ b/docs/plans/v10/implementation-plan.md
@@ -563,6 +563,31 @@ unreachable on a client with no database. Each of our fixtures overrides it with
       SQLite classes, never in the 35 relational bases** (verified: every `AssertSql` in those 35
       is the declaration or an empty call).
 
+- [x] **R27. `OwnedTableSplitting` — the first genuinely new family, and it lands at 4 red of 70.**
+      A new fixture on `OwnedTableSplittingRelationalFixtureBase` and four classes adopted bare.
+      **Four and not seven: EF ships no `BulkUpdate`, `Collection` or `SetOperations` class for
+      this family.** The mapping is the one `OwnedNavigations` switches *off* — an owned reference
+      lives in its owner's table and only an owned collection gets a table of its own — which is
+      why `OwnedNavigationsRelationalFixtureBase` derives from this one and overrides precisely
+      that. Nothing is mirrored by hand, `AreCollectionsOrdered` included.
+      `Passed: 66, Failed: 4, Total: 70`. **All four are two tests times two arms, and the reason
+      is the one R26 already priced: SQLite has no `APPLY`.**
+      `Projection.Select_subquery_required_related_FirstOrDefault` and
+      `…_optional_related_FirstOrDefault`, `NoTracking` raising the APPLY message bare and
+      `TrackAll` reaching `AssertOwnedTrackingQuery` expecting *"A tracking query is attempting to
+      project"*.
+      **EF's `OwnedTableSplittingProjectionSqliteTest` is commented out in full** — the same EF
+      issue #26708 that disables `OwnedNavigationsProjectionSqliteTest` — so once again there is
+      no upstream override to adopt and `OwnedJsonProjectionSqliteTest` is the nearest statement of
+      the same limit. Two families now, same gap, same substitute.
+      **One thing of EF's is deliberately not adopted and it is worth naming: their SQLite fixture
+      adds `ConfigureWarnings(b => b.Ignore(SqliteEventId.CompositeKeyWithValueGeneration))`.**
+      Not needed here and measured rather than assumed — 66 of 70 pass with no such failure, and
+      an unnecessary warning-ignore in a fixture is the kind of thing that later hides a real one.
+      `OwnedTableSplittingStructuralEqualitySqliteTest` is not adopted either: its overrides are
+      golden SQL only, those tests pass here on the relational base's own assertion, and the SQL is
+      the backing store's text, which this client never emits.
+
 ## Phase S — the query parameters still inlined as SQL literals (#62)
 
 **Not a milestone.** #59 fixed two shapes of one defect and a sweep counted what survived: 379

--- a/docs/plans/v10/implementation-plan.md
+++ b/docs/plans/v10/implementation-plan.md
@@ -477,6 +477,47 @@ only a fraction of what it hid.
       That is exactly the distinction ADR-013's 2026-08-30 amendment draws.
       95 / 0 / 95 → 97 / 96 / 1. `failed` 70 → 71, `total` +2. `test/` only.
 
+### R25–R30 — the `Query.Associations` relational family (35 bases)
+
+The 35 `Query.Associations.*RelationalTestBase` classes are a third of the 95 the compliance
+test still lists. EF ships a complete SQLite counterpart for every one of them, fixtures
+included, and **none of them carries `FromSql`, `ToQueryString`, or a `RelationalTestStore`
+cast** — the four things that blocked bases earlier in Phase R. **Nor is there any golden SQL:
+across all 35 there are zero `AssertSql("…")` calls with an argument. Every use is either the
+`protected void AssertSql(params string[] expected)` declaration or an empty `AssertSql()`
+meaning "nothing was executed".** That corrects a C0-era remark in
+`ComplexPropertiesQueryInfoCarrierTests.cs` which said these bases "assert SQL and stay
+unadopted"; they do not.
+
+**What an empty `AssertSql()` is worth here, stated honestly.** It reads the *client's*
+`TestSqlLoggerFactory`, and this client has no database and emits no SQL, so the assertion
+passes trivially. Weaker than it is on SQLite, not false. `ServerSqlLog` is where the server's
+statements can be read.
+
+**The `UseTransaction` trap is on the FIXTURE here, not the base.** Grepping these test bases
+for `ExecuteWithStrategyInTransactionAsync` finds nothing, and that is not clearance: every
+`*RelationalFixtureBase` in the family declares
+`UseTransaction(facade, t) => facade.UseTransaction(t.GetDbTransaction())`, which ADR-013 makes
+unreachable on a client with no database. Each of our fixtures overrides it with
+`facade.UseInfoCarrierTransaction(transaction)`, in the same commit as the fixture.
+
+- [x] **R25. The seven `Navigations` bases — a pure re-parent, and it cost nothing.** The
+      fixture moves from the core `NavigationsFixtureBase` to `NavigationsRelationalFixtureBase`
+      and the seven classes from `Navigations*TestBase` to `Navigations*RelationalTestBase`.
+      **Six hand-written overrides are deleted, because the re-parent now inherits them
+      verbatim**: the two `Distinct_over_projected_*` (C2 copied them out of
+      `NavigationsCollectionRelationalTestBase`), `Select_nested_collection_on_optional_associate`,
+      `Over_associate_collection_projected`, and the three `Nested_collection_*`. The fixture's
+      hand-mirrored six `AutoInclude()` calls go the same way — they were
+      `NavigationsRelationalFixtureBase.OnModelCreating`, mirrored in C0 because the test project
+      did not then reference `EFCore.Relational.Specification.Tests`. What stays is EF's own
+      `Navigations*SqliteTest` overrides, three `SqliteStrings.ApplyNotSupported` assertions the
+      relational bases do not carry.
+      The relational bases add no test of their own, so this is measurable in one figure:
+      `Passed: 336, Failed: 0, Total: 336` across all three Associations families before and
+      after, and `Passed: 109, Failed: 0, Total: 109` for `Navigations` alone. `failed` and
+      `total` both unchanged; compliance missing 95 → 88, fixtures 23 → 22. `test/` only.
+
 ## Phase S — the query parameters still inlined as SQL literals (#62)
 
 **Not a milestone.** #59 fixed two shapes of one defect and a sweep counted what survived: 379

--- a/docs/plans/v10/implementation-plan.md
+++ b/docs/plans/v10/implementation-plan.md
@@ -588,6 +588,16 @@ unreachable on a client with no database. Each of our fixtures overrides it with
       golden SQL only, those tests pass here on the relational base's own assertion, and the SQL is
       the backing store's text, which this client never emits.
 
+- [x] **R27a. The `OwnedTableSplitting` override subset — 4 of 4 answered, and the family is
+      green.** `Passed: 406, Failed: 0, Total: 406` for the whole `Query.Associations` tree, which
+      is R26a's 336 plus this family's 70. Both overrides are `OwnedJsonProjectionSqliteTest`'s,
+      character for character, because #26708 leaves EF with no `OwnedTableSplitting` projection
+      class to take them from. **Baseline moves for the first time this block: `failed` unchanged
+      at 71, `total` 27026 → 27096**, and `known-failures.names.txt` is untouched because no
+      failure is added or removed. The two `InfoCarrierComplianceTest` entries stay red by design;
+      what falls is what their assertion prints (95 → 82 bases, 23 → 21 fixtures), not their
+      status.
+
 ## Phase S — the query parameters still inlined as SQL literals (#62)
 
 **Not a milestone.** #59 fixed two shapes of one defect and a sweep counted what survived: 379

--- a/test/InfoCarrier.Core.FunctionalTests/Sqlite/Query/Associations/NavigationsQueryInfoCarrierTests.cs
+++ b/test/InfoCarrier.Core.FunctionalTests/Sqlite/Query/Associations/NavigationsQueryInfoCarrierTests.cs
@@ -2,13 +2,13 @@
 
 using InfoCarrier.Core.FunctionalTests.TestUtilities;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.EntityFrameworkCore.Query.Associations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Query.Associations.Navigations;
 using Microsoft.EntityFrameworkCore.Sqlite.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
-using Xunit.Sdk;
+using Xunit.Abstractions;
 
 // Internal EF Core API usage. This provider is built on EF Core internals by design
 // (CLAUDE.md), and EF Core's own providers suppress EF1001 the same way at the point of use.
@@ -17,8 +17,8 @@ using Xunit.Sdk;
 namespace InfoCarrier.Core.FunctionalTests.Sqlite.Query.Associations;
 
 /// <summary>
-///     The shared fixture for the seven <c>Navigations*TestBase</c> classes below, on ADR-009
-///     <b>Tier B</b>.
+///     The shared fixture for the seven <c>Navigations*RelationalTestBase</c> classes below, on
+///     ADR-009 <b>Tier B</b>.
 /// </summary>
 /// <remarks>
 ///     <para>
@@ -27,20 +27,20 @@ namespace InfoCarrier.Core.FunctionalTests.Sqlite.Query.Associations;
 ///         "could go either way" here for A81's rule to adjudicate.
 ///     </para>
 ///     <para>
-///         The <em>core</em> fixture, which is where the model and the data live —
-///         <c>AssociationsQueryFixtureBase</c>, <c>AssociationsData</c>, <c>AssociationsModel</c>
-///         and <c>NavigationsFixtureBase</c> are all in <c>EFCore.Specification.Tests</c>. The
-///         relational assembly adds only <em>mapping-strategy</em> variants — <c>ComplexJson</c>,
-///         <c>OwnedJson</c>, <c>ComplexTableSplitting</c>, <c>OwnedTableSplitting</c> — which the
-///         compliance test does not ask for and each of which would need a hand-mirrored model, the
-///         cost B3d priced at ~630 lines. Adopting the core family and not those is deliberate.
+///         <b>R25 re-parented this onto <c>NavigationsRelationalFixtureBase</c>.</b> C0 adopted the
+///         core fixture and mirrored the relational one's six <c>AutoInclude()</c> calls by hand,
+///         because the test project did not then reference
+///         <c>EFCore.Relational.Specification.Tests</c>. ADR-013 made that reference available and
+///         the hand copy is now the real thing: the base supplies the auto-includes, the
+///         <c>ITestSqlLoggerFactory</c> the relational test bases need, and a <c>StoreName</c> this
+///         class still overrides.
 ///     </para>
 ///     <para>
 ///         Its own <c>StoreName</c>, per CLAUDE.md: the Tier B store is file-backed and two
 ///         fixtures sharing a name share a database.
 ///     </para>
 /// </remarks>
-public class NavigationsQueryInfoCarrierFixture : NavigationsFixtureBase
+public class NavigationsQueryInfoCarrierFixture : NavigationsRelationalFixtureBase
 {
     private ITestStoreFactory? _testStoreFactory;
 
@@ -59,79 +59,42 @@ public class NavigationsQueryInfoCarrierFixture : NavigationsFixtureBase
 
     /// <inheritdoc />
     /// <remarks>
-    ///     <para>
-    ///         The six <c>AutoInclude()</c> calls are <c>NavigationsRelationalFixtureBase</c>'s,
-    ///         mirrored by hand because this project references only the core specification
-    ///         assembly. <b>They are not decoration — they are what the facet is about.</b> Every
-    ///         query in these seven classes returns bare <c>RootEntity</c> rows and no test writes
-    ///         an <c>Include</c>, yet <c>AssociationsQueryFixtureBase.AssertRootEntity</c> walks the
-    ///         whole association graph and compares it against the fully-populated
-    ///         <c>AssociationsData</c>. Without the auto-includes the associates are simply not
-    ///         loaded, and <b>63 of the first run's 79 failures were one <c>Values differ</c></b> —
-    ///         <c>Expected: Root5_RequiredAssociate, Actual: null</c>, out of that asserter.
-    ///     </para>
-    ///     <para>
-    ///         Safe to mirror, and the reason is worth stating: <c>AutoInclude</c> is a
-    ///         <em>core</em> modelling API, so it is a statement both models make for themselves
-    ///         from the same <c>OnModelCreating</c> — not something one side computes and the other
-    ///         has to agree with (the B4/B6/B12 hazard).
-    ///     </para>
+    ///     <b>The <c>UseTransaction</c> that CLAUDE.md says to write in the same commit as the
+    ///     store switch — except that here it is the fixture, not the base, that carries it.</b>
+    ///     Grepping these bases for <c>ExecuteWithStrategyInTransactionAsync</c> finds nothing;
+    ///     what needs the override is <c>NavigationsRelationalFixtureBase.UseTransaction</c>
+    ///     itself, which calls <c>transaction.GetDbTransaction()</c> and is unreachable on a client
+    ///     with no database (ADR-013). The provider has its own enlistment (Phase T / M4).
     /// </remarks>
-    protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
-    {
-        base.OnModelCreating(modelBuilder, context);
-
-        modelBuilder.Entity<RootEntity>(b =>
-        {
-            b.Navigation(e => e.RequiredAssociate).AutoInclude();
-            b.Navigation(e => e.OptionalAssociate).AutoInclude();
-            b.Navigation(e => e.AssociateCollection).AutoInclude();
-        });
-
-        modelBuilder.Entity<AssociateType>(b =>
-        {
-            b.Navigation(e => e.RequiredNestedAssociate).AutoInclude();
-            b.Navigation(e => e.OptionalNestedAssociate).AutoInclude();
-            b.Navigation(e => e.NestedCollection).AutoInclude();
-        });
-    }
+    public override void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
+        => facade.UseInfoCarrierTransaction(transaction);
 }
 
-// The seven Navigations facets (ADR-004). Adopting these also satisfies the seven shared
-// `Associations*TestBase` bases, which they derive from and which ComplianceTestBase resolves
+// The seven Navigations facets (ADR-004), on their relational bases since R25. Adopting these
+// also satisfies the seven core `Navigations*TestBase` classes and the seven shared
+// `Associations*TestBase` ones, which they derive from and which ComplianceTestBase resolves
 // transitively.
 //
-// The overrides below are all EF's own, from `Navigations*RelationalTestBase` and
-// `Navigations*SqliteTest`, and each was matched by *reason* before being taken (A63): every one
-// of them is a limit of the backing store or of relational translation generally, raised here from
-// the same place with the same message. Nothing else is overridden, and nothing here is red:
-// the four `Index_*` (and four more on `OwnedNavigations`) were closed by C69, which forwards the
-// one warning `AssertOrderedCollectionQuery` contracts for to the server that raises it — see
-// `AssociationsWarnings`. C55 had diagnosed them and left them red on the belief that the event
-// could only be forwarded globally, at 26 broken; all 26 turned out to be in Northwind and
-// BulkUpdates classes, none in these families.
+// R25 deleted six overrides that this file used to restate by hand -- the two
+// `Distinct_over_projected_*`, `Select_nested_collection_on_optional_associate`,
+// `Over_associate_collection_projected` and the three `Nested_collection_*` ones. Every one was
+// copied out of a `Navigations*RelationalTestBase`, and the re-parent inherits them verbatim.
+// What is left below is EF's `Navigations*SqliteTest` overrides, which the relational bases do
+// not carry: each is a limit of the backing store, raised here from the same place with the same
+// message.
+//
+// The relational bases add no test of their own. What they add is `AssertSql`, and it is worth
+// being honest about what that is worth here: it reads the *client's* TestSqlLoggerFactory, and
+// this client has no database and emits no SQL. No base in this family calls it with an argument
+// -- every call is the empty `AssertSql()` meaning "nothing was executed" -- so the assertion is
+// true here but trivially so, weaker than it is on SQLite rather than false. `ServerSqlLog` is
+// where the server's statements can actually be read.
 
-public class NavigationsCollectionQueryInfoCarrierTest(NavigationsQueryInfoCarrierFixture fixture)
-    : NavigationsCollectionTestBase<NavigationsQueryInfoCarrierFixture>(fixture)
+public class NavigationsCollectionQueryInfoCarrierTest(
+    NavigationsQueryInfoCarrierFixture fixture,
+    ITestOutputHelper testOutputHelper)
+    : NavigationsCollectionRelationalTestBase<NavigationsQueryInfoCarrierFixture>(fixture, testOutputHelper)
 {
-    /// <summary>
-    ///     <c>NavigationsCollectionRelationalTestBase</c>'s two: <c>Distinct</c> over a projected
-    ///     collection is something no relational provider can express, and EF states it on the
-    ///     relational base rather than in SQLite's suite.
-    /// </summary>
-    public override async Task Distinct_over_projected_nested_collection()
-        => Assert.Equal(
-            RelationalStrings.DistinctOnCollectionNotSupported,
-            (await Assert.ThrowsAsync<InvalidOperationException>(
-                base.Distinct_over_projected_nested_collection)).Message);
-
-    /// <inheritdoc cref="Distinct_over_projected_nested_collection" />
-    public override async Task Distinct_over_projected_filtered_nested_collection()
-        => Assert.Equal(
-            RelationalStrings.DistinctOnCollectionNotSupported,
-            (await Assert.ThrowsAsync<InvalidOperationException>(
-                base.Distinct_over_projected_filtered_nested_collection)).Message);
-
     /// <summary>
     ///     <c>NavigationsCollectionSqliteTest</c>'s: the query reaches SQL and asks SQLite for
     ///     <c>APPLY</c>, which it does not have.
@@ -145,32 +108,26 @@ public class NavigationsCollectionQueryInfoCarrierTest(NavigationsQueryInfoCarri
             (await Assert.ThrowsAsync<InvalidOperationException>(query)).Message);
 }
 
-public class NavigationsIncludeQueryInfoCarrierTest(NavigationsQueryInfoCarrierFixture fixture)
-    : NavigationsIncludeTestBase<NavigationsQueryInfoCarrierFixture>(fixture);
+public class NavigationsIncludeQueryInfoCarrierTest(
+    NavigationsQueryInfoCarrierFixture fixture,
+    ITestOutputHelper testOutputHelper)
+    : NavigationsIncludeRelationalTestBase<NavigationsQueryInfoCarrierFixture>(fixture, testOutputHelper);
 
-public class NavigationsMiscellaneousQueryInfoCarrierTest(NavigationsQueryInfoCarrierFixture fixture)
-    : NavigationsMiscellaneousTestBase<NavigationsQueryInfoCarrierFixture>(fixture);
+public class NavigationsMiscellaneousQueryInfoCarrierTest(
+    NavigationsQueryInfoCarrierFixture fixture,
+    ITestOutputHelper testOutputHelper)
+    : NavigationsMiscellaneousRelationalTestBase<NavigationsQueryInfoCarrierFixture>(fixture, testOutputHelper);
 
-public class NavigationsPrimitiveCollectionQueryInfoCarrierTest(NavigationsQueryInfoCarrierFixture fixture)
-    : NavigationsPrimitiveCollectionTestBase<NavigationsQueryInfoCarrierFixture>(fixture);
+public class NavigationsPrimitiveCollectionQueryInfoCarrierTest(
+    NavigationsQueryInfoCarrierFixture fixture,
+    ITestOutputHelper testOutputHelper)
+    : NavigationsPrimitiveCollectionRelationalTestBase<NavigationsQueryInfoCarrierFixture>(fixture, testOutputHelper);
 
-public class NavigationsProjectionQueryInfoCarrierTest(NavigationsQueryInfoCarrierFixture fixture)
-    : NavigationsProjectionTestBase<NavigationsQueryInfoCarrierFixture>(fixture)
+public class NavigationsProjectionQueryInfoCarrierTest(
+    NavigationsQueryInfoCarrierFixture fixture,
+    ITestOutputHelper testOutputHelper)
+    : NavigationsProjectionRelationalTestBase<NavigationsQueryInfoCarrierFixture>(fixture, testOutputHelper)
 {
-    /// <summary>
-    ///     <c>NavigationsProjectionRelationalTestBase</c>'s. A relational store returns an
-    ///     <em>empty</em> collection where the owner is null, not a null collection, so EF rewrites
-    ///     the expected side rather than the query.
-    /// </summary>
-    public override Task Select_nested_collection_on_optional_associate(QueryTrackingBehavior queryTrackingBehavior)
-        => AssertQuery(
-            ss => ss.Set<RootEntity>().OrderBy(e => e.Id).Select(x => x.OptionalAssociate!.NestedCollection),
-            ss => ss.Set<RootEntity>().OrderBy(e => e.Id)
-                .Select(x => x.OptionalAssociate!.NestedCollection ?? new List<NestedAssociateType>()),
-            assertOrder: true,
-            elementAsserter: (e, a) => AssertCollection(e, a, elementSorter: r => r.Id),
-            queryTrackingBehavior: queryTrackingBehavior);
-
     /// <summary>
     ///     <c>NavigationsProjectionSqliteTest</c>'s two, both <c>APPLY</c>.
     /// </summary>
@@ -184,35 +141,12 @@ public class NavigationsProjectionQueryInfoCarrierTest(NavigationsQueryInfoCarri
             () => base.Select_subquery_optional_related_FirstOrDefault(queryTrackingBehavior));
 }
 
-public class NavigationsSetOperationsQueryInfoCarrierTest(NavigationsQueryInfoCarrierFixture fixture)
-    : NavigationsSetOperationsTestBase<NavigationsQueryInfoCarrierFixture>(fixture)
-{
-    /// <summary>
-    ///     <c>NavigationsSetOperationsRelationalTestBase</c>'s, for EF issues #33485 and #34849.
-    /// </summary>
-    public override async Task Over_associate_collection_projected(QueryTrackingBehavior queryTrackingBehavior)
-        => Assert.Equal(
-            RelationalStrings.InsufficientInformationToIdentifyElementOfCollectionJoin,
-            (await Assert.ThrowsAsync<InvalidOperationException>(
-                () => base.Over_associate_collection_projected(queryTrackingBehavior))).Message);
-}
+public class NavigationsSetOperationsQueryInfoCarrierTest(
+    NavigationsQueryInfoCarrierFixture fixture,
+    ITestOutputHelper testOutputHelper)
+    : NavigationsSetOperationsRelationalTestBase<NavigationsQueryInfoCarrierFixture>(fixture, testOutputHelper);
 
-public class NavigationsStructuralEqualityQueryInfoCarrierTest(NavigationsQueryInfoCarrierFixture fixture)
-    : NavigationsStructuralEqualityTestBase<NavigationsQueryInfoCarrierFixture>(fixture)
-{
-    /// <summary>
-    ///     <c>NavigationsStructuralEqualityRelationalTestBase</c>'s three, with EF's reason: a
-    ///     traditional relational collection navigation cannot be compared reliably — a collection
-    ///     on a null instance comes back empty rather than null, and element order is not preserved.
-    /// </summary>
-    public override Task Two_nested_collections()
-        => Assert.ThrowsAsync<EqualException>(() => base.Two_nested_collections());
-
-    /// <inheritdoc cref="Two_nested_collections" />
-    public override Task Nested_collection_with_inline()
-        => Assert.ThrowsAsync<InvalidOperationException>(() => base.Nested_collection_with_inline());
-
-    /// <inheritdoc cref="Two_nested_collections" />
-    public override Task Nested_collection_with_parameter()
-        => Assert.ThrowsAsync<InvalidOperationException>(() => base.Nested_collection_with_parameter());
-}
+public class NavigationsStructuralEqualityQueryInfoCarrierTest(
+    NavigationsQueryInfoCarrierFixture fixture,
+    ITestOutputHelper testOutputHelper)
+    : NavigationsStructuralEqualityRelationalTestBase<NavigationsQueryInfoCarrierFixture>(fixture, testOutputHelper);

--- a/test/InfoCarrier.Core.FunctionalTests/Sqlite/Query/Associations/OwnedNavigationsQueryInfoCarrierTests.cs
+++ b/test/InfoCarrier.Core.FunctionalTests/Sqlite/Query/Associations/OwnedNavigationsQueryInfoCarrierTests.cs
@@ -1,49 +1,41 @@
 // Licensed under the MIT license. See license.txt file in the project root for license information.
 
 using InfoCarrier.Core.FunctionalTests.TestUtilities;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.EntityFrameworkCore.Query.Associations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Query.Associations.OwnedNavigations;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestUtilities;
-using Xunit;
+using Xunit.Abstractions;
 
 namespace InfoCarrier.Core.FunctionalTests.Sqlite.Query.Associations;
 
 /// <summary>
-///     The shared fixture for the six <c>OwnedNavigations*TestBase</c> classes below, on ADR-009
-///     <b>Tier B</b> (C0).
+///     The shared fixture for the six <c>OwnedNavigations*RelationalTestBase</c> classes below, on
+///     ADR-009 <b>Tier B</b>.
 /// </summary>
 /// <remarks>
 ///     <para>
-///         Unlike C1's, this family's <em>core</em> fixture is complete on its own: it maps the
-///         whole owned graph and only the table <em>layout</em> is relational.
-///         <c>OwnedNavigationsRelationalFixtureBase</c> exists solely to move each owned navigation
-///         to its own table with <c>ToTable</c>, disabling the default table splitting — a physical
-///         choice these tests do not assert, since the SQL-asserting bases are the ones we do not
-///         take. No auto-includes either: an owned dependent comes with its owner's row by
-///         definition, which is the same fact B10 turned on.
+///         <b>R26 re-parented this onto <c>OwnedNavigationsRelationalFixtureBase</c>.</b> C0 mapped
+///         the family on the core fixture and mirrored the relational one's <c>ToTable</c> calls by
+///         hand — <c>OwnedTableSplittingRelationalFixtureBase</c>'s and
+///         <c>OwnedNavigationsRelationalFixtureBase</c>'s, in that order — because the test project
+///         did not then reference <c>EFCore.Relational.Specification.Tests</c>. The hand copy also
+///         mirrored <c>AreCollectionsOrdered</c>. All of it is now the real thing, and the copy was
+///         not complete: the base also calls <c>ValueGeneratedNever()</c> on every owned key and
+///         states <c>IsRequired</c> on the associate navigations, neither of which C0 carried.
 ///     </para>
 ///     <para>
-///         <c>AreCollectionsOrdered</c> <b>is</b> mirrored, and is the one thing here that has to
-///         be. The relational fixture sets it false because a relational store does not preserve
-///         the order of an owned collection; the core fixture leaves the base's <c>true</c>
-///         standing because a document store does. The backing store here is SQLite, so the
-///         relational answer is the true one — and this is a statement about the <em>store</em>,
-///         which is exactly the class of thing this project must mirror by hand.
+///         Its own <c>StoreName</c>, per CLAUDE.md: the Tier B store is file-backed and two
+///         fixtures sharing a name share a database.
 ///     </para>
 /// </remarks>
-public class OwnedNavigationsQueryInfoCarrierFixture : OwnedNavigationsFixtureBase
+public class OwnedNavigationsQueryInfoCarrierFixture : OwnedNavigationsRelationalFixtureBase
 {
     private ITestStoreFactory? _testStoreFactory;
 
     /// <inheritdoc />
     protected override string StoreName
         => "OwnedNavigationsQueryInfoCarrierTest";
-
-    /// <inheritdoc />
-    public override bool AreCollectionsOrdered
-        => false;
 
     /// <inheritdoc />
     protected override ITestStoreFactory TestStoreFactory
@@ -56,237 +48,42 @@ public class OwnedNavigationsQueryInfoCarrierFixture : OwnedNavigationsFixtureBa
 
     /// <inheritdoc />
     /// <remarks>
-    ///     <para>
-    ///         The <c>ToTable</c> calls are <c>OwnedTableSplittingRelationalFixtureBase</c>'s and
-    ///         <c>OwnedNavigationsRelationalFixtureBase</c>'s, in that order, mirrored by hand.
-    ///         <b>Without them the model does not validate at all</b> — <i>"The table
-    ///         'RootEntity_NestedCollection' cannot be used for entity type …"</i>, 69 of the first
-    ///         run's 81 failures, because three different owners each have a <c>NestedCollection</c>
-    ///         and the default table-splitting convention gives all three the same table name.
-    ///     </para>
-    ///     <para>
-    ///         Precedent and reason: B3c mirrored <c>ToJson()</c> the same way. A physical table
-    ///         name is the backing store's business and the client has no store — but both sides
-    ///         run this one <c>OnModelCreating</c>, so if the mapping is not stated here it is not
-    ///         stated at all, and the server's model is the one that has to be valid.
-    ///     </para>
+    ///     The fixture, not the base, is what carries the <c>UseTransaction</c> trap in this
+    ///     family; see <see cref="NavigationsQueryInfoCarrierFixture.UseTransaction" />.
     /// </remarks>
-    protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
-    {
-        base.OnModelCreating(modelBuilder, context);
-
-        // OwnedTableSplittingRelationalFixtureBase: every owned *collection* gets its own table.
-        modelBuilder.Entity<RootEntity>(b =>
-        {
-            b.OwnsOne(
-                e => e.RequiredAssociate,
-                rrb => rrb.OwnsMany(r => r.NestedCollection, rcb => rcb.ToTable("RequiredRelated_NestedCollection")));
-
-            b.OwnsOne(
-                e => e.OptionalAssociate,
-                orb => orb.OwnsMany(r => r.NestedCollection, rcb => rcb.ToTable("OptionalRelated_NestedCollection")));
-
-            b.OwnsMany(
-                e => e.AssociateCollection, rcb =>
-                {
-                    rcb.ToTable("RelatedCollection");
-                    rcb.OwnsMany(r => r.NestedCollection, rnb => rnb.ToTable("RelatedCollection_NestedCollection"));
-                });
-        });
-
-        // OwnedNavigationsRelationalFixtureBase: and every owned *reference* too, which is what
-        // makes this family "owned navigations mapped to separate tables" rather than splitting.
-        modelBuilder.Entity<RootEntity>(b =>
-        {
-            b.OwnsOne(
-                e => e.RequiredAssociate, rrb =>
-                {
-                    rrb.ToTable("RequiredRelated");
-                    rrb.OwnsOne(r => r.RequiredNestedAssociate, rnb => rnb.ToTable("RequiredRelated_RequiredNested"));
-                    rrb.OwnsOne(r => r.OptionalNestedAssociate, rnb => rnb.ToTable("RequiredRelated_OptionalNested"));
-                });
-
-            b.OwnsOne(
-                e => e.OptionalAssociate, orb =>
-                {
-                    orb.ToTable("OptionalRelated");
-                    orb.OwnsOne(r => r.RequiredNestedAssociate, rnb => rnb.ToTable("OptionalRelated_RequiredNested"));
-                    orb.OwnsOne(r => r.OptionalNestedAssociate, rnb => rnb.ToTable("OptionalRelated_OptionalNested"));
-                });
-
-            b.OwnsMany(
-                e => e.AssociateCollection, rcb =>
-                {
-                    rcb.OwnsOne(r => r.RequiredNestedAssociate, rnb => rnb.ToTable("RelatedCollection_RequiredNested"));
-                    rcb.OwnsOne(r => r.OptionalNestedAssociate, rnb => rnb.ToTable("RelatedCollection_OptionalNested"));
-                });
-        });
-    }
+    public override void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
+        => facade.UseInfoCarrierTransaction(transaction);
 }
 
-// The six OwnedNavigations facets (ADR-004), starting with no overrides. Every failure is real
-// information, triaged in docs/plans/v10/implementation-plan.md under C2.
+// The six OwnedNavigations facets (ADR-004), adopted bare on their relational bases: no override
+// at all, so that every failure is measured before anything is written to answer it.
 
-public class OwnedNavigationsCollectionQueryInfoCarrierTest(OwnedNavigationsQueryInfoCarrierFixture fixture)
-    : OwnedNavigationsCollectionTestBase<OwnedNavigationsQueryInfoCarrierFixture>(fixture)
-{
-    /// <summary>
-    ///     <c>OwnedNavigationsCollectionRelationalTestBase</c>'s two, and
-    ///     <c>OwnedNavigationsCollectionSqliteTest</c>'s one. Same limits as C1's, from the same
-    ///     places.
-    /// </summary>
-    public override async Task Distinct_over_projected_nested_collection()
-        => Assert.Equal(
-            RelationalStrings.DistinctOnCollectionNotSupported,
-            (await Assert.ThrowsAsync<InvalidOperationException>(
-                base.Distinct_over_projected_nested_collection)).Message);
+public class OwnedNavigationsCollectionQueryInfoCarrierTest(
+    OwnedNavigationsQueryInfoCarrierFixture fixture,
+    ITestOutputHelper testOutputHelper)
+    : OwnedNavigationsCollectionRelationalTestBase<OwnedNavigationsQueryInfoCarrierFixture>(fixture, testOutputHelper);
 
-    /// <inheritdoc cref="Distinct_over_projected_nested_collection" />
-    public override async Task Distinct_over_projected_filtered_nested_collection()
-        => Assert.Equal(
-            RelationalStrings.DistinctOnCollectionNotSupported,
-            (await Assert.ThrowsAsync<InvalidOperationException>(
-                base.Distinct_over_projected_filtered_nested_collection)).Message);
+public class OwnedNavigationsMiscellaneousQueryInfoCarrierTest(
+    OwnedNavigationsQueryInfoCarrierFixture fixture,
+    ITestOutputHelper testOutputHelper)
+    : OwnedNavigationsMiscellaneousRelationalTestBase<OwnedNavigationsQueryInfoCarrierFixture>(fixture, testOutputHelper);
 
-    /// <summary>
-    ///     <c>OwnedNavigationsCollectionSqliteTest</c>'s, adopted whole in C57 including its
-    ///     <c>TrackAll</c> arm.
-    /// </summary>
-    /// <remarks>
-    ///     The <c>TrackAll</c> half used to go through <see cref="Distinct_projected" />'s APPLY
-    ///     assertion and failed <i>"expected InvalidOperationException, actual EqualException"</i>
-    ///     — because <c>AssertOwnedTrackingQuery</c> compares against <i>"A tracking query is
-    ///     attempting to project an owned entity…"</i> and gets <c>ApplyNotSupported</c> instead.
-    ///     That is EF's own comment word for word: <i>"Base test expects 'can't track owned
-    ///     entities' exception, but with SQLite we get 'no CROSS APPLY'"</i>. The reason matches,
-    ///     so the override does too (A63).
-    /// </remarks>
-    public override Task Distinct_projected(QueryTrackingBehavior queryTrackingBehavior)
-        => queryTrackingBehavior is QueryTrackingBehavior.TrackAll
-            ? Task.CompletedTask
-            : NavigationsCollectionQueryInfoCarrierTest.AssertApplyNotSupported(
-                () => base.Distinct_projected(queryTrackingBehavior));
-}
+public class OwnedNavigationsPrimitiveCollectionQueryInfoCarrierTest(
+    OwnedNavigationsQueryInfoCarrierFixture fixture,
+    ITestOutputHelper testOutputHelper)
+    : OwnedNavigationsPrimitiveCollectionRelationalTestBase<OwnedNavigationsQueryInfoCarrierFixture>(fixture, testOutputHelper);
 
-public class OwnedNavigationsMiscellaneousQueryInfoCarrierTest(OwnedNavigationsQueryInfoCarrierFixture fixture)
-    : OwnedNavigationsMiscellaneousTestBase<OwnedNavigationsQueryInfoCarrierFixture>(fixture);
+public class OwnedNavigationsProjectionQueryInfoCarrierTest(
+    OwnedNavigationsQueryInfoCarrierFixture fixture,
+    ITestOutputHelper testOutputHelper)
+    : OwnedNavigationsProjectionRelationalTestBase<OwnedNavigationsQueryInfoCarrierFixture>(fixture, testOutputHelper);
 
-public class OwnedNavigationsPrimitiveCollectionQueryInfoCarrierTest(OwnedNavigationsQueryInfoCarrierFixture fixture)
-    : OwnedNavigationsPrimitiveCollectionTestBase<OwnedNavigationsQueryInfoCarrierFixture>(fixture);
+public class OwnedNavigationsSetOperationsQueryInfoCarrierTest(
+    OwnedNavigationsQueryInfoCarrierFixture fixture,
+    ITestOutputHelper testOutputHelper)
+    : OwnedNavigationsSetOperationsRelationalTestBase<OwnedNavigationsQueryInfoCarrierFixture>(fixture, testOutputHelper);
 
-public class OwnedNavigationsProjectionQueryInfoCarrierTest(OwnedNavigationsQueryInfoCarrierFixture fixture)
-    : OwnedNavigationsProjectionTestBase<OwnedNavigationsQueryInfoCarrierFixture>(fixture)
-{
-    /// <summary>
-    ///     <c>OwnedNavigationsProjectionRelationalTestBase</c>'s two. The second is a full test
-    ///     replacement rather than an exception assertion, and EF states why: a traditional
-    ///     relational collection navigation projected from a <see langword="null" /> instance comes
-    ///     back as an <em>empty</em> collection, not as null — which is the opposite of both client
-    ///     evaluation and the JSON collection behaviour. Ours failed with <c>Assert.Null() Failure:
-    ///     Value is not null</c>, which is that sentence stated from the other side.
-    /// </summary>
-    public override Task Select_required_associate_via_optional_navigation(QueryTrackingBehavior queryTrackingBehavior)
-        => AssertOwnedTrackingQuery(
-            queryTrackingBehavior,
-            () => base.Select_required_associate_via_optional_navigation(queryTrackingBehavior));
-
-    /// <inheritdoc cref="Select_required_associate_via_optional_navigation" />
-    public override Task Select_nested_collection_on_optional_associate(QueryTrackingBehavior queryTrackingBehavior)
-        => queryTrackingBehavior is QueryTrackingBehavior.TrackAll
-            ? base.Select_nested_collection_on_optional_associate(queryTrackingBehavior)
-            : AssertQuery(
-                ss => ss.Set<RootEntity>().OrderBy(e => e.Id).Select(x => x.OptionalAssociate!.NestedCollection),
-                ss => ss.Set<RootEntity>().OrderBy(e => e.Id)
-                    .Select(x => x.OptionalAssociate!.NestedCollection ?? new List<NestedAssociateType>()),
-                assertOrder: true,
-                elementAsserter: (e, a) => AssertCollection(e, a, elementSorter: r => r.Id),
-                queryTrackingBehavior: queryTrackingBehavior);
-
-    /// <summary>
-    ///     SQLite has no <c>APPLY</c>, and <c>OwnedJsonProjectionSqliteTest</c> borrows the same
-    ///     limit — <b>including its <c>TrackAll</c> arm, which C57 corrects.</b>
-    /// </summary>
-    /// <remarks>
-    ///     C20 declined EF's no-op here on the ground that <i>"here <c>TrackAll</c> fails on a
-    ///     string comparison instead, which is a different statement"</i>. **It is the same
-    ///     statement, and reading the comparison says so**: <c>Expected: "A tracking query is
-    ///     attempting to project"</c>, <c>Actual: "Translating this query requires the SQL
-    ///     APPLY"</c> — which is EF's comment verbatim, <i>"Base test expects 'can't track owned
-    ///     entities' exception, but with SQLite we get 'no CROSS APPLY'"</i>. A63 applies; the
-    ///     decline rested on not having read the two strings.
-    ///     <c>OwnedNavigationsProjectionSqliteTest</c> itself is commented out in EF for an
-    ///     unrelated reason (issue #26708), so <c>OwnedJson</c>'s is the nearest statement of it.
-    /// </remarks>
-    public override Task Select_subquery_optional_related_FirstOrDefault(QueryTrackingBehavior queryTrackingBehavior)
-        => queryTrackingBehavior is QueryTrackingBehavior.TrackAll
-            ? Task.CompletedTask
-            : NavigationsCollectionQueryInfoCarrierTest.AssertApplyNotSupported(
-                () => base.Select_subquery_optional_related_FirstOrDefault(queryTrackingBehavior));
-
-    /// <inheritdoc cref="Select_subquery_optional_related_FirstOrDefault" />
-    public override Task Select_subquery_required_related_FirstOrDefault(QueryTrackingBehavior queryTrackingBehavior)
-        => queryTrackingBehavior is QueryTrackingBehavior.TrackAll
-            ? Task.CompletedTask
-            : NavigationsCollectionQueryInfoCarrierTest.AssertApplyNotSupported(
-                () => base.Select_subquery_required_related_FirstOrDefault(queryTrackingBehavior));
-}
-
-public class OwnedNavigationsSetOperationsQueryInfoCarrierTest(OwnedNavigationsQueryInfoCarrierFixture fixture)
-    : OwnedNavigationsSetOperationsTestBase<OwnedNavigationsQueryInfoCarrierFixture>(fixture)
-{
-    /// <summary>
-    ///     <c>OwnedNavigationsSetOperationsRelationalTestBase</c>'s two, with EF's reasons: issues
-    ///     #33485 / #34849 for the first, and for the second that an owned navigation models each
-    ///     property as its own structural type even when the CLR type is shared, so a set operation
-    ///     over two of them is a set operation over different types.
-    /// </summary>
-    /// <remarks>
-    ///     <b>C57: the first of the two is SQLite's limit, not the relational base's.</b> This
-    ///     asserted <c>InsufficientInformationToIdentifyElementOfCollectionJoin</c> — which is
-    ///     right for <c>Navigations</c>, where it passes — and got
-    ///     <c>ApplyNotSupported</c>. <c>OwnedNavigationsSetOperationsSqliteTest</c> says the same
-    ///     thing in the form its inheritance chain allows: <i>"SQL APPLY not supported in SQLite —
-    ///     different exception message from the one expected in the base class"</i>, wrapped as
-    ///     <c>Assert.ThrowsAsync&lt;EqualException&gt;</c> because <em>its</em> base is the
-    ///     relational one that makes the assertion. Ours is the core base, so the fact is stated
-    ///     directly instead of through a nested assertion failure.
-    /// </remarks>
-    public override Task Over_associate_collection_projected(QueryTrackingBehavior queryTrackingBehavior)
-        => NavigationsCollectionQueryInfoCarrierTest.AssertApplyNotSupported(
-            () => base.Over_associate_collection_projected(queryTrackingBehavior));
-
-    /// <inheritdoc cref="Over_associate_collection_projected" />
-    public override async Task Over_different_collection_properties()
-        => Assert.Equal(
-            RelationalStrings.SetOperationOverDifferentStructuralTypes(
-                "RootEntity.RequiredAssociate#AssociateType.NestedCollection#NestedAssociateType",
-                "RootEntity.OptionalAssociate#AssociateType.NestedCollection#NestedAssociateType"),
-            (await Assert.ThrowsAsync<InvalidOperationException>(
-                base.Over_different_collection_properties)).Message);
-}
-
-public class OwnedNavigationsStructuralEqualityQueryInfoCarrierTest(OwnedNavigationsQueryInfoCarrierFixture fixture)
-    : OwnedNavigationsStructuralEqualityTestBase<OwnedNavigationsQueryInfoCarrierFixture>(fixture)
-{
-    /// <summary>
-    ///     <c>OwnedNavigationsStructuralEqualityRelationalTestBase</c>'s four. EF asserts only the
-    ///     exception type and records the message in a comment, because an owned collection under a
-    ///     relational store carries a synthesized ordinal key and shadow foreign keys that
-    ///     <c>Contains</c> cannot read — <i>"no backing field could be found … and the property does
-    ///     not have a getter"</i>. Asserted the same way here, for the same reason.
-    /// </summary>
-    public override Task Contains_with_inline()
-        => Assert.ThrowsAsync<InvalidOperationException>(base.Contains_with_inline);
-
-    /// <inheritdoc cref="Contains_with_inline" />
-    public override Task Contains_with_parameter()
-        => Assert.ThrowsAsync<InvalidOperationException>(base.Contains_with_parameter);
-
-    /// <inheritdoc cref="Contains_with_inline" />
-    public override Task Contains_with_operators_composed_on_the_collection()
-        => Assert.ThrowsAsync<InvalidOperationException>(base.Contains_with_operators_composed_on_the_collection);
-
-    /// <inheritdoc cref="Contains_with_inline" />
-    public override Task Contains_with_nested_and_composed_operators()
-        => Assert.ThrowsAsync<InvalidOperationException>(base.Contains_with_nested_and_composed_operators);
-}
+public class OwnedNavigationsStructuralEqualityQueryInfoCarrierTest(
+    OwnedNavigationsQueryInfoCarrierFixture fixture,
+    ITestOutputHelper testOutputHelper)
+    : OwnedNavigationsStructuralEqualityRelationalTestBase<OwnedNavigationsQueryInfoCarrierFixture>(fixture, testOutputHelper);

--- a/test/InfoCarrier.Core.FunctionalTests/Sqlite/Query/Associations/OwnedNavigationsQueryInfoCarrierTests.cs
+++ b/test/InfoCarrier.Core.FunctionalTests/Sqlite/Query/Associations/OwnedNavigationsQueryInfoCarrierTests.cs
@@ -2,10 +2,13 @@
 
 using InfoCarrier.Core.FunctionalTests.TestUtilities;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Query.Associations.OwnedNavigations;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
 using Xunit.Abstractions;
+using Xunit.Sdk;
 
 namespace InfoCarrier.Core.FunctionalTests.Sqlite.Query.Associations;
 
@@ -55,13 +58,43 @@ public class OwnedNavigationsQueryInfoCarrierFixture : OwnedNavigationsRelationa
         => facade.UseInfoCarrierTransaction(transaction);
 }
 
-// The six OwnedNavigations facets (ADR-004), adopted bare on their relational bases: no override
-// at all, so that every failure is measured before anything is written to answer it.
+// The six OwnedNavigations facets (ADR-004). R26 adopted them bare and measured 8 red of 91;
+// R26a is the override subset, and every one of the eight was the same reason -- SQLite has no
+// APPLY -- so every override below comes from EF's own SQLite suite.
+//
+// The four `Contains_*` assertions, the two `Distinct_over_projected_*` and the two rewrites in
+// `Projection` that this file used to restate by hand are all gone: they were
+// `OwnedNavigations*RelationalTestBase`'s, and the re-parent inherits them verbatim.
+//
+// What is deliberately NOT adopted from EF's SQLite suite:
+// `OwnedNavigationsStructuralEqualitySqliteTest` overrides several tests purely to assert golden
+// SQL. Those pass here on the relational base's own assertion, and the golden SQL is the
+// *backing store's* statement text, which this client never emits -- taking them would assert
+// nothing and would couple this file to SQLite's formatting.
 
 public class OwnedNavigationsCollectionQueryInfoCarrierTest(
     OwnedNavigationsQueryInfoCarrierFixture fixture,
     ITestOutputHelper testOutputHelper)
-    : OwnedNavigationsCollectionRelationalTestBase<OwnedNavigationsQueryInfoCarrierFixture>(fixture, testOutputHelper);
+    : OwnedNavigationsCollectionRelationalTestBase<OwnedNavigationsQueryInfoCarrierFixture>(fixture, testOutputHelper)
+{
+    /// <summary>
+    ///     <c>OwnedNavigationsCollectionSqliteTest</c>'s, adopted whole including its
+    ///     <c>TrackAll</c> arm and EF's reason for it.
+    /// </summary>
+    /// <remarks>
+    ///     Both arms measured as APPLY in R26: <c>NoTracking</c> raised
+    ///     <c>SqliteStrings.ApplyNotSupported</c> bare, and <c>TrackAll</c> reached
+    ///     <c>AssertOwnedTrackingQuery</c> expecting <i>"A tracking query is attempting to
+    ///     project"</i> and got the APPLY message instead. That is EF's comment word for word:
+    ///     <i>"Base test expects 'can't track owned entities' exception, but with SQLite we get
+    ///     'no CROSS APPLY'"</i>. Reason matched before the override was taken (A63).
+    /// </remarks>
+    public override Task Distinct_projected(QueryTrackingBehavior queryTrackingBehavior)
+        => queryTrackingBehavior is QueryTrackingBehavior.TrackAll
+            ? Task.CompletedTask
+            : NavigationsCollectionQueryInfoCarrierTest.AssertApplyNotSupported(
+                () => base.Distinct_projected(queryTrackingBehavior));
+}
 
 public class OwnedNavigationsMiscellaneousQueryInfoCarrierTest(
     OwnedNavigationsQueryInfoCarrierFixture fixture,
@@ -76,12 +109,62 @@ public class OwnedNavigationsPrimitiveCollectionQueryInfoCarrierTest(
 public class OwnedNavigationsProjectionQueryInfoCarrierTest(
     OwnedNavigationsQueryInfoCarrierFixture fixture,
     ITestOutputHelper testOutputHelper)
-    : OwnedNavigationsProjectionRelationalTestBase<OwnedNavigationsQueryInfoCarrierFixture>(fixture, testOutputHelper);
+    : OwnedNavigationsProjectionRelationalTestBase<OwnedNavigationsQueryInfoCarrierFixture>(fixture, testOutputHelper)
+{
+    /// <summary>
+    ///     The same APPLY limit in the same two arms, but <b>EF ships no
+    ///     <c>OwnedNavigationsProjectionSqliteTest</c> to take it from.</b> That whole class is
+    ///     commented out upstream, for EF issue #26708 (<i>"Stop generating composite keys for
+    ///     owned collections on SQLite"</i>), so there is no override there to adopt.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <c>OwnedJsonProjectionSqliteTest</c> is the nearest statement of the same limit and
+    ///         is where these two bodies come from, character for character including the
+    ///         <c>TrackAll</c> arm. C20 and C57 already borrowed from there for the same reason.
+    ///     </para>
+    ///     <para>
+    ///         <b>Worth recording rather than quietly enjoying: the rest of this class passes
+    ///         here.</b> R26 measured it with no override at all and only these two tests failed,
+    ///         in both arms. That is an observation about a class EF does not run, not a claim
+    ///         that #26708 is fixed, and nothing here depends on which it is.
+    ///     </para>
+    /// </remarks>
+    public override Task Select_subquery_required_related_FirstOrDefault(QueryTrackingBehavior queryTrackingBehavior)
+        => queryTrackingBehavior is QueryTrackingBehavior.TrackAll
+            ? Task.CompletedTask
+            : NavigationsCollectionQueryInfoCarrierTest.AssertApplyNotSupported(
+                () => base.Select_subquery_required_related_FirstOrDefault(queryTrackingBehavior));
+
+    /// <inheritdoc cref="Select_subquery_required_related_FirstOrDefault" />
+    public override Task Select_subquery_optional_related_FirstOrDefault(QueryTrackingBehavior queryTrackingBehavior)
+        => queryTrackingBehavior is QueryTrackingBehavior.TrackAll
+            ? Task.CompletedTask
+            : NavigationsCollectionQueryInfoCarrierTest.AssertApplyNotSupported(
+                () => base.Select_subquery_optional_related_FirstOrDefault(queryTrackingBehavior));
+}
 
 public class OwnedNavigationsSetOperationsQueryInfoCarrierTest(
     OwnedNavigationsQueryInfoCarrierFixture fixture,
     ITestOutputHelper testOutputHelper)
-    : OwnedNavigationsSetOperationsRelationalTestBase<OwnedNavigationsQueryInfoCarrierFixture>(fixture, testOutputHelper);
+    : OwnedNavigationsSetOperationsRelationalTestBase<OwnedNavigationsQueryInfoCarrierFixture>(fixture, testOutputHelper)
+{
+    /// <summary>
+    ///     <c>OwnedNavigationsSetOperationsSqliteTest</c>'s, now adoptable <em>verbatim</em>, and
+    ///     that is the clearest single thing the re-parent bought.
+    /// </summary>
+    /// <remarks>
+    ///     EF writes this as <c>Assert.ThrowsAsync&lt;EqualException&gt;</c>: the relational base
+    ///     asserts <c>InsufficientInformationToIdentifyElementOfCollectionJoin</c>, SQLite raises
+    ///     the APPLY message instead, and the nested assertion failure <em>is</em> the statement.
+    ///     C57 could not write it that way, because this class then sat on the <em>core</em> base,
+    ///     which makes no assertion to fail; it asserted the APPLY message directly and explained
+    ///     the divergence in a paragraph. On the relational base EF's one line means here exactly
+    ///     what it means upstream, and the paragraph is no longer needed.
+    /// </remarks>
+    public override Task Over_associate_collection_projected(QueryTrackingBehavior queryTrackingBehavior)
+        => Assert.ThrowsAsync<EqualException>(() => base.Over_associate_collection_projected(queryTrackingBehavior));
+}
 
 public class OwnedNavigationsStructuralEqualityQueryInfoCarrierTest(
     OwnedNavigationsQueryInfoCarrierFixture fixture,

--- a/test/InfoCarrier.Core.FunctionalTests/Sqlite/Query/Associations/OwnedTableSplittingQueryInfoCarrierTests.cs
+++ b/test/InfoCarrier.Core.FunctionalTests/Sqlite/Query/Associations/OwnedTableSplittingQueryInfoCarrierTests.cs
@@ -1,0 +1,86 @@
+// Licensed under the MIT license. See license.txt file in the project root for license information.
+
+using InfoCarrier.Core.FunctionalTests.TestUtilities;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Query.Associations.OwnedTableSplitting;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit.Abstractions;
+
+namespace InfoCarrier.Core.FunctionalTests.Sqlite.Query.Associations;
+
+/// <summary>
+///     The shared fixture for the four <c>OwnedTableSplitting*RelationalTestBase</c> classes below,
+///     on ADR-009 <b>Tier B</b> (R27).
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>A new family, not a re-parent</b>, and the first of four this repository has never
+///         run. It is the owned-entity mapping that <see cref="OwnedNavigationsQueryInfoCarrierFixture" />
+///         switches <em>off</em>: an owned reference lives in its owner's table (table splitting)
+///         and only an owned collection gets a table of its own.
+///         <c>OwnedNavigationsRelationalFixtureBase</c> derives from this one and overrides
+///         precisely that, with a <c>ToTable</c> per owned reference.
+///     </para>
+///     <para>
+///         <b>Tier B</b>, for C0's reason unchanged: <c>EFCore.InMemory.FunctionalTests</c> ships
+///         no <c>Associations</c> directory at all, and table splitting is a statement about tables,
+///         so the tier that translates is the only one whose green means anything.
+///     </para>
+///     <para>
+///         Nothing is mirrored by hand. The whole model, <c>AreCollectionsOrdered</c> included,
+///         comes from <c>OwnedTableSplittingRelationalFixtureBase</c>. Its own <c>StoreName</c>,
+///         per CLAUDE.md: the Tier B store is file-backed and two fixtures sharing a name share a
+///         database.
+///     </para>
+/// </remarks>
+public class OwnedTableSplittingQueryInfoCarrierFixture : OwnedTableSplittingRelationalFixtureBase
+{
+    private ITestStoreFactory? _testStoreFactory;
+
+    /// <inheritdoc />
+    protected override string StoreName
+        => "OwnedTableSplittingQueryInfoCarrierTest";
+
+    /// <inheritdoc />
+    protected override ITestStoreFactory TestStoreFactory
+        => _testStoreFactory ??= InfoCarrierTestStoreFactory.Create(
+            InfoCarrierTestStoreFactory.Sqlite,
+            ContextType,
+            (modelBuilder, context) => OnModelCreating(modelBuilder, context),
+            onAddOptions: AssociationsWarnings.ThrowOnUnorderedRowLimiting,
+            configureConventions: ConfigureConventions);
+
+    /// <inheritdoc />
+    /// <remarks>
+    ///     The fixture, not the base, is what carries the <c>UseTransaction</c> trap in this
+    ///     family; see <see cref="NavigationsQueryInfoCarrierFixture.UseTransaction" />.
+    /// </remarks>
+    public override void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
+        => facade.UseInfoCarrierTransaction(transaction);
+}
+
+// The four OwnedTableSplitting facets (ADR-004), adopted bare: no override at all, so that every
+// failure is measured and classified before anything is written to answer it. EF ships no
+// BulkUpdate, Collection or SetOperations class for this family, which is why it is four and not
+// seven.
+
+public class OwnedTableSplittingMiscellaneousQueryInfoCarrierTest(
+    OwnedTableSplittingQueryInfoCarrierFixture fixture,
+    ITestOutputHelper testOutputHelper)
+    : OwnedTableSplittingMiscellaneousRelationalTestBase<OwnedTableSplittingQueryInfoCarrierFixture>(fixture, testOutputHelper);
+
+public class OwnedTableSplittingPrimitiveCollectionQueryInfoCarrierTest(
+    OwnedTableSplittingQueryInfoCarrierFixture fixture,
+    ITestOutputHelper testOutputHelper)
+    : OwnedTableSplittingPrimitiveCollectionRelationalTestBase<OwnedTableSplittingQueryInfoCarrierFixture>(fixture, testOutputHelper);
+
+public class OwnedTableSplittingProjectionQueryInfoCarrierTest(
+    OwnedTableSplittingQueryInfoCarrierFixture fixture,
+    ITestOutputHelper testOutputHelper)
+    : OwnedTableSplittingProjectionRelationalTestBase<OwnedTableSplittingQueryInfoCarrierFixture>(fixture, testOutputHelper);
+
+public class OwnedTableSplittingStructuralEqualityQueryInfoCarrierTest(
+    OwnedTableSplittingQueryInfoCarrierFixture fixture,
+    ITestOutputHelper testOutputHelper)
+    : OwnedTableSplittingStructuralEqualityRelationalTestBase<OwnedTableSplittingQueryInfoCarrierFixture>(fixture, testOutputHelper);

--- a/test/InfoCarrier.Core.FunctionalTests/Sqlite/Query/Associations/OwnedTableSplittingQueryInfoCarrierTests.cs
+++ b/test/InfoCarrier.Core.FunctionalTests/Sqlite/Query/Associations/OwnedTableSplittingQueryInfoCarrierTests.cs
@@ -1,6 +1,7 @@
 // Licensed under the MIT license. See license.txt file in the project root for license information.
 
 using InfoCarrier.Core.FunctionalTests.TestUtilities;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Query.Associations.OwnedTableSplitting;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -60,10 +61,21 @@ public class OwnedTableSplittingQueryInfoCarrierFixture : OwnedTableSplittingRel
         => facade.UseInfoCarrierTransaction(transaction);
 }
 
-// The four OwnedTableSplitting facets (ADR-004), adopted bare: no override at all, so that every
-// failure is measured and classified before anything is written to answer it. EF ships no
-// BulkUpdate, Collection or SetOperations class for this family, which is why it is four and not
-// seven.
+// The four OwnedTableSplitting facets (ADR-004). EF ships no BulkUpdate, Collection or
+// SetOperations class for this family, which is why it is four and not seven.
+//
+// R27 adopted them bare and measured 4 red of 70; R27a is the override subset below, and all four
+// were one reason -- SQLite has no APPLY.
+//
+// Two things of EF's are deliberately NOT adopted:
+//
+//  - `OwnedTableSplittingStructuralEqualitySqliteTest` overrides several tests purely to assert
+//    golden SQL. They pass here on the relational base's own assertion, and the SQL is the
+//    *backing store's* statement text, which this client never emits.
+//  - EF's `OwnedTableSplittingSqliteFixture` adds
+//    `ConfigureWarnings(b => b.Ignore(SqliteEventId.CompositeKeyWithValueGeneration))`. Not needed
+//    here, and measured rather than assumed: R27's bare run passed 66 of 70 with no such failure.
+//    An unnecessary warning-ignore in a fixture is the kind of thing that later hides a real one.
 
 public class OwnedTableSplittingMiscellaneousQueryInfoCarrierTest(
     OwnedTableSplittingQueryInfoCarrierFixture fixture,
@@ -78,7 +90,36 @@ public class OwnedTableSplittingPrimitiveCollectionQueryInfoCarrierTest(
 public class OwnedTableSplittingProjectionQueryInfoCarrierTest(
     OwnedTableSplittingQueryInfoCarrierFixture fixture,
     ITestOutputHelper testOutputHelper)
-    : OwnedTableSplittingProjectionRelationalTestBase<OwnedTableSplittingQueryInfoCarrierFixture>(fixture, testOutputHelper);
+    : OwnedTableSplittingProjectionRelationalTestBase<OwnedTableSplittingQueryInfoCarrierFixture>(fixture, testOutputHelper)
+{
+    /// <summary>
+    ///     The whole of R27's red: SQLite has no <c>APPLY</c>, in both
+    ///     <c>QueryTrackingBehavior</c> arms. <b>EF ships no
+    ///     <c>OwnedTableSplittingProjectionSqliteTest</c> to take the override from</b> — that
+    ///     class is commented out upstream in full, for the same EF issue #26708 that disables
+    ///     <c>OwnedNavigationsProjectionSqliteTest</c>.
+    /// </summary>
+    /// <remarks>
+    ///     So these two bodies come from <c>OwnedJsonProjectionSqliteTest</c>, character for
+    ///     character, exactly as
+    ///     <see cref="OwnedNavigationsProjectionQueryInfoCarrierTest.Select_subquery_required_related_FirstOrDefault" />
+    ///     does. <b>Two families now with the same upstream gap and the same substitute</b>, which
+    ///     is worth stating once: #26708 costs EF two SQLite classes, and this provider runs both
+    ///     of them with two tests red in each.
+    /// </remarks>
+    public override Task Select_subquery_required_related_FirstOrDefault(QueryTrackingBehavior queryTrackingBehavior)
+        => queryTrackingBehavior is QueryTrackingBehavior.TrackAll
+            ? Task.CompletedTask
+            : NavigationsCollectionQueryInfoCarrierTest.AssertApplyNotSupported(
+                () => base.Select_subquery_required_related_FirstOrDefault(queryTrackingBehavior));
+
+    /// <inheritdoc cref="Select_subquery_required_related_FirstOrDefault" />
+    public override Task Select_subquery_optional_related_FirstOrDefault(QueryTrackingBehavior queryTrackingBehavior)
+        => queryTrackingBehavior is QueryTrackingBehavior.TrackAll
+            ? Task.CompletedTask
+            : NavigationsCollectionQueryInfoCarrierTest.AssertApplyNotSupported(
+                () => base.Select_subquery_optional_related_FirstOrDefault(queryTrackingBehavior));
+}
 
 public class OwnedTableSplittingStructuralEqualityQueryInfoCarrierTest(
     OwnedTableSplittingQueryInfoCarrierFixture fixture,

--- a/test/known-failures.txt
+++ b/test/known-failures.txt
@@ -1244,5 +1244,21 @@
 # assumption disqualified JsonTypesRelationalTestBase wholesale in R23; here it costs one test,
 # which is the distinction ADR-013's amendment draws, so the base is adopted and the test is left
 # failing per ADR-004. FIXED none.
+#
+# 2026-08-31, #56 (R25-R27a). `failed` UNCHANGED at 71, `total` 27026 -> 27096 for the 70 tests
+# the new OwnedTableSplitting family brings. The Query.Associations relational block adopts the
+# 35 `*RelationalTestBase` classes; R25 (Navigations, 7) and R26/R26a (OwnedNavigations, 6) are
+# pure re-parents of families already running and add no test at all -- measured as
+# `Passed: 336, Failed: 0, Total: 336` before and after each. R27/R27a adds the four
+# OwnedTableSplitting classes, a family this repository has never run: `Passed: 406, Failed: 0,
+# Total: 406` for the whole Associations tree afterwards, so all 70 are green.
+#
+# FIXED none, BROKEN none, and known-failures.names.txt is unchanged: no failure is added or
+# removed. The two InfoCarrierComplianceTest entries stay in it and stay red by design -- the
+# missing-base list falls 95 -> 82 and the missing-fixture list 23 -> 21, which lowers what the
+# assertion prints without making it pass.
+#
+# The +70 is the delta measured by a local --filter run, to be confirmed by CI's Spec ratchet,
+# which is the only thing that produces the absolute figures.
 failed=71
-total=27026
+total=27096


### PR DESCRIPTION
Third of six families in the `Query.Associations` relational block (#56), and **the first genuinely new one** — this repository has never run it. **Stacked on #83** (which is stacked on #82); merge in order #82 → #83 → this.

## The family

A new fixture on `OwnedTableSplittingRelationalFixtureBase` and four classes. **Four and not seven: EF ships no `BulkUpdate`, `Collection` or `SetOperations` class for it.**

The mapping is the one `OwnedNavigations` switches *off* — an owned reference lives in its owner's table, and only an owned collection gets a table of its own. That is why `OwnedNavigationsRelationalFixtureBase` derives from this one and overrides precisely that.

Nothing is mirrored by hand, `AreCollectionsOrdered` included. `UseTransaction` is written in the same commit as the fixture, per CLAUDE.md.

## R27 — bare: `Passed: 66, Failed: 4, Total: 70`

All four are **two tests × two `QueryTrackingBehavior` arms, one reason: SQLite has no `APPLY`** — the reason R26 already priced.

| Test | `NoTracking` | `TrackAll` |
|---|---|---|
| `Projection.Select_subquery_required_related_FirstOrDefault` | APPLY message raw | expected *"A tracking query is attempting to project"*, got APPLY |
| `Projection.Select_subquery_optional_related_FirstOrDefault` | same | same |

## R27a — overrides

Both bodies are `OwnedJsonProjectionSqliteTest`'s, character for character. **EF's `OwnedTableSplittingProjectionSqliteTest` is commented out in full**, for the same EF issue #26708 that disables `OwnedNavigationsProjectionSqliteTest`. Two families now with the same upstream gap and the same substitute.

### Deliberately not adopted, both recorded in the file

- `OwnedTableSplittingStructuralEqualitySqliteTest` overrides several tests purely to assert golden SQL. They pass here on the relational base's own assertion, and the SQL is the *backing store's* statement text, which this client never emits.
- EF's `OwnedTableSplittingSqliteFixture` adds `ConfigureWarnings(b => b.Ignore(SqliteEventId.CompositeKeyWithValueGeneration))`. Not needed here, and **measured rather than assumed** — R27's bare run passed 66 of 70 with no such failure. An unnecessary warning-ignore in a fixture is the kind of thing that later hides a real one.

## Result

| | |
|---|---|
| Whole `Query.Associations` tree | `Passed: 406, Failed: 0, Total: 406` (R26a's 336 + this family's 70) |
| Compliance missing bases | 82 → 78 |
| Compliance missing fixtures | unchanged at 21 (the new fixture implements `ITestSqlLoggerFactory` via its base) |

**Baseline moves for the first time in this block:** `failed` unchanged at **71**, `total` **27026 → 27096**. `known-failures.names.txt` is untouched — no failure is added or removed. The two `InfoCarrierComplianceTest` entries stay red by design; what falls is what their assertion *prints*, not their status.

The +70 is a local `--filter` delta, to be confirmed by the Spec ratchet, which is the only thing that produces the absolute figures.

`test/` only. `CI=true dotnet build InfoCarrier.Core.slnx --configuration Release` reports `5 Warning(s), 0 Error(s)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)