### PR TITLE
Tier D, a document store, and the defect it found is fixed in the same change

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,6 +126,19 @@ jobs:
           dotnet test test/InfoCarrier.Core.TransportTests/InfoCarrier.Core.TransportTests.csproj
           --no-build --configuration Release
 
+      # ADR-009 TIER D, and it is gated HERE rather than folded into the spec ratchet for the same
+      # reason the transport suite is: it is expected green and it adopts no specification bases,
+      # so its count would inflate the ratchet's total past what test/known-failures.txt was
+      # written against.
+      #
+      # It starts a real mongod, one per test class, from binaries Mongo2Go carries in its own
+      # package. Nothing is downloaded and no container is used, which is the bar ADR-009 set when
+      # it chose Firebird over PostgreSQL. About seven seconds including the server starts.
+      - name: Test (document store, Tier D)
+        run: >
+          dotnet test test/InfoCarrier.Core.DocumentStoreTests/InfoCarrier.Core.DocumentStoreTests.csproj
+          --no-build --configuration Release
+
       # Phase 2 of M8. Publishes the Blazor client trimmed and gates on the DIRECTION of this
       # product's IL2xxx count, not on zero — spec §9's "no warning attributable to
       # InfoCarrier.Core" is not met and eng/trim-baseline.txt records why. The script publishes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,22 @@ longer about whether the client is relational**; this file and `architecture.md`
 until R135, and `architecture.md` §6a carries the **D3 amendment 2026-09-03 (R135)** with the
 measurement.
 
+**TIER D IS AN EMBEDDED MONGODB SINCE 2026-09-10, IN A PROJECT OF ITS OWN
+(`test/InfoCarrier.Core.DocumentStoreTests`), AND IT ADOPTS NO SPEC BASES.** It exists to prove a
+negative that no relational tier can: that this provider is not relational-only (#51). A compliance
+test here demanding every base be adopted against a document store would misread it. It is gated
+beside the transport suite rather than by the spec ratchet, for the same reason that suite is, and
+it is deliberately **absent from `eng/measure.sh`**. Its own project exists because
+`MongoDB.EntityFrameworkCore` needs EF Core >= 10.0.11 while `src/` compiles against a 10.0.1 floor,
+which also makes it the one place the product runs on a NEWER EF Core than it was built with.
+**It found #100 on its first run and the same change fixes it**: updating an entity that owns
+nested documents lost them over the wire, and a scalar update lost them silently. The fix widens
+the owner-expansion in `InfoCarrierDatabase.Expand` that C86/C87/C95 built for JSON columns, which
+was bounded by `GetContainerColumnName()` and therefore blind to a store with no columns, and adds
+the direction that case never needed: a root being written pulls its own document along. **Gated on
+`UseNonRelationalServerStore()`, so a relational deployment's payload is unchanged.** ADR-009's
+2026-09-10 amendment is the reading.
+
 **Point test runs at each `.csproj`, never at the `.slnx`**, and prefer `eng/measure.sh`, which runs
 every project in its own `projects` list and adds the figures. **That list holds the spec project
 alone, and `InfoCarrier.Core.TransportTests` is deliberately absent** — it is this repository's own

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -113,5 +113,20 @@
       test green by accident, which is the failure mode this repository treats as a defect.
     -->
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.10.0" />
+
+    <!--
+      TIER D, TEST-ONLY, AND THE STORE ARRIVES IN THE PACKAGE. Mongo2Go embeds the mongod,
+      mongoimport and mongoexport binaries for win-x64, linux-x64/arm64 and osx-x64/arm64, so a
+      run downloads nothing and installs nothing. That is the same bar Firebird met and the reason
+      PostgreSQL did not: EphemeralMongo, the obvious package for this, FETCHES the binaries at
+      first use into local app data, which ADR-009 already rejected once.
+
+      MongoDB.EntityFrameworkCore REQUIRES EF Core >= 10.0.11, above this repository's 10.0.1
+      floor. That is deliberate rather than tolerated: it makes the test project resolve EF ABOVE
+      what src/ compiles against, which is the arrangement a consumer is really in and the one
+      that would have caught the 10.1.1 defect months earlier.
+    -->
+    <PackageVersion Include="Mongo2Go" Version="5.0.0" />
+    <PackageVersion Include="MongoDB.EntityFrameworkCore" Version="10.0.3" />
   </ItemGroup>
 </Project>

--- a/InfoCarrier.Core.slnx
+++ b/InfoCarrier.Core.slnx
@@ -12,5 +12,6 @@
   <Folder Name="/test/">
     <Project Path="test/InfoCarrier.Core.FunctionalTests/InfoCarrier.Core.FunctionalTests.csproj" />
     <Project Path="test/InfoCarrier.Core.TransportTests/InfoCarrier.Core.TransportTests.csproj" />
+    <Project Path="test/InfoCarrier.Core.DocumentStoreTests/InfoCarrier.Core.DocumentStoreTests.csproj" />
   </Folder>
 </Solution>

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -307,6 +307,78 @@ something. Running a base on two tiers is duplication, not coverage.
 must never appear in `src/`. `eng/measure.sh` needs no change, because the tiers are namespaces in
 one project.
 
+### Amendment 2026-09-10 — Tier D, a document store, and it proves a negative rather than adding coverage
+
+**Tier D is MongoDB, embedded, and it exists for one claim** (#51): that this provider is not
+relational-only. Tiers B and C were added to GAIN coverage, a base needing transactions and a base
+needing a table-valued function. This one is a different kind of tier and the difference is the
+whole design.
+
+**It adopts NO specification bases and has NO compliance test, deliberately.** A
+`MongoComplianceTest` scanning the core specification assembly would demand every base be adopted
+against a document store, which is neither possible nor the point. If one ever appears here, it has
+misread the tier. What lives here instead is a small set of tests whose green means something no
+relational store can mean.
+
+**`InMemorySmokeTest` already wrote this tier's brief and called its own evidence weak, by name:**
+"WEAK EVIDENCE ON PURPOSE, and issue #51 says why: InMemory has no nested-document shape and no
+translation refusals of its own, so it disagrees with a relational store about almost nothing. A
+document-store tier is what would answer the question properly. This is the cheap half."
+
+**Mongo2Go, not EphemeralMongo, and that is the same trade Firebird won.** ADR-009 rejected
+PostgreSQL because its binaries are fetched at first run; the constraint was no installation and no
+container. EphemeralMongo is the obvious package here and fails the same test, downloading `mongod`
+into local app data. Mongo2Go carries the binaries inside its own NuGet package for win-x64,
+linux-x64/arm64 and osx-x64/arm64, which is how Firebird qualified.
+
+**A SINGLE-NODE REPLICA SET, NOT A STANDALONE.** The MongoDB EF provider wraps `SaveChanges` in a
+transaction, and MongoDB has transactions only on a replica set. `MongoDbRunner.Start()` throws on
+the first save; `MongoDbRunner.Start(singleNodeReplSet: true)` is required.
+
+**ONE SERVER PER STORE, OWNED BY THE TEST CLASS, AND THE ALTERNATIVE WAS MEASURED FIRST.** Sharing
+one `mongod` across the tier is cheaper on paper: startup is ~930 ms warm and each further database
+costs ~108 ms, flat, against ~930 ms for each further server. It was still rejected. xUnit 2.x has
+no assembly-level fixture, so sharing needs a static that is never disposed, which orphans a process
+when a run is killed, and it reintroduces the class of bug that already cost this repository a
+nine-test intermittent when a shared SQLite store's disposal raced a live one. Per-store, the class
+that started the server stops it and there is nothing to get wrong.
+
+**The cost of that choice is bounded by CONCURRENCY rather than by tier size**, which is what makes
+it safe to grow. xUnit runs test classes in parallel, so N classes start N servers at the same time:
+the wall clock is roughly one startup rather than N, and a `mongod` holding a test dataset uses
+about 150 MB, not the 7.6 GB its WiredTiger cache is configured for. Measured: 22 tests across four
+classes and four servers run in about seven seconds including every start.
+
+**A PROJECT OF ITS OWN, for a reason R136 did not have.** `MongoDB.EntityFrameworkCore` requires
+Entity Framework Core >= 10.0.11 and `src/` compiles against a 10.0.1 floor on purpose. In one
+project central package management refuses the graph (NU1109), and forcing it would drag the whole
+29,000-test suite onto a different EF Core patch than the product is built against. Keeping it apart
+also gives the tier a second, unplanned virtue: it runs the product on a NEWER EF Core than it was
+built with, which is the configuration a consumer is really in and the one that would have caught
+the defect `10.1.1` fixed.
+
+**It is gated with the transport suite and not by the spec ratchet**, for the reason that suite is:
+it is expected green and adopts no bases, so folding its count in would inflate the ratchet's total
+past what `test/known-failures.txt` was written against.
+
+**It found a defect on its first run and that defect is fixed in the same change, which is the
+argument for having built it** (#100). Updating an entity that owns nested documents lost them over
+the wire, and a scalar update lost them silently, writing a document with the nested parts gone and
+failing only on the next read. A server-side control performing the same updates directly against
+MongoDB passed throughout, so the fault was never the store's.
+
+**The same defect had already been solved once, for JSON columns** (C86, C87, C95): an owner that
+is `Unchanged` never reaches `IDatabase.SaveChanges`, so `InfoCarrierDatabase.Expand` sends it
+anyway. That machinery was bounded by `GetContainerColumnName()`, which is a RELATIONAL question,
+and a document store answers it nowhere. The fix widens the bound to any owned type when the store
+is not relational, and adds the direction the JSON case never needed: a ROOT being written pulls
+its own document along, because writing a customer writes the whole customer document.
+
+**It is gated on `UseNonRelationalServerStore()`, so a relational deployment sends exactly what it
+sent before.** That switch already states the store is not relational and already decides which
+queries the client will compose; it now decides how much of a document travels with a change. A
+client pointed at a document store must set it, which was already true for queries.
+
 ## ADR-010 — Projection split: boundary computed on the client — LOCKED (2026-08-01)
 
 **Context.** Requirements §3: the server holds only the shared entity assembly, so it cannot

--- a/src/InfoCarrier.Core/InfoCarrierDatabase.cs
+++ b/src/InfoCarrier.Core/InfoCarrierDatabase.cs
@@ -47,6 +47,22 @@ public class InfoCarrierDatabase(
             .First()
             .InfoCarrierClient!;
     private readonly Metadata.IInfoCarrierDocumentMapping _documentMapping = documentMapping;
+
+    /// <summary>
+    ///     Whether the server's store writes rows rather than documents
+    ///     (<see cref="InfoCarrierDbContextOptionsBuilder.UseNonRelationalServerStore" />).
+    /// </summary>
+    /// <remarks>
+    ///     <b>It decides how much of a document has to travel with a change (#100).</b> On a
+    ///     relational store an owned type is columns, or a row with a key of its own, and the
+    ///     server can write the change it was given. On a document store the owned types ARE the
+    ///     owner's document, so a change to any part of it can only be written by writing the
+    ///     whole.
+    /// </remarks>
+    private readonly bool _serverStoreIsRelational = options.Extensions
+            .OfType<InfoCarrierOptionsExtension>()
+            .First()
+            .ServerStoreIsRelational;
     private readonly IExpressionSerializer _expressionSerializer = expressionSerializer;
     private readonly ICurrentDbContext _currentContext = currentContext;
     private readonly IDiagnosticsLogger<DbLoggerCategory.Update> _updateLogger = updateLogger;
@@ -340,6 +356,29 @@ public class InfoCarrierDatabase(
                     }
                 }
             }
+
+            // AND THE OTHER DIRECTION, WHICH THE JSON CASE NEVER NEEDED (#100). Above, an owned
+            // entry pulls its owner along. Here a ROOT pulls its own document along, and on a
+            // document store it has to: writing a customer writes the whole customer document, so
+            // an address the client did not touch is not merely absent from the change set, it is
+            // absent from what gets written. The save then SUCCEEDS and stores a document with the
+            // address gone, which is data loss with no error, and the next read fails on the
+            // missing field rather than the write.
+            //
+            // A relational store never has this problem and never pays for this: `ToJson()` writes
+            // the container column from the owner's own values, and every other owned type is
+            // columns or a row of its own that the server can write untouched. So this is bounded
+            // by the same switch, and a relational deployment sends exactly what it sent before.
+            if (!_serverStoreIsRelational)
+            {
+                foreach (IUpdateEntry member in JsonDocumentMembers(entry))
+                {
+                    if (!sent.Contains(member) && seen.Add(member))
+                    {
+                        yield return member;
+                    }
+                }
+            }
         }
 
         foreach (IUpdateEntry entry in entries)
@@ -367,7 +406,7 @@ public class InfoCarrierDatabase(
         foreach (InternalEntityEntry candidate in ownerEntry.StateManager.Entries)
         {
             if (!ReferenceEquals(candidate, ownerEntry)
-                && _documentMapping.FindContainerName(candidate.EntityType) is not null
+                && PartOfOneDocument(candidate.EntityType)
                 && JsonColumnOwners(candidate).Any(o => ReferenceEquals(o, ownerEntry)))
             {
                 yield return candidate;
@@ -376,8 +415,30 @@ public class InfoCarrierDatabase(
     }
 
     /// <summary>
-    ///     The chain of owners above a JSON-mapped entry, nearest first, or nothing at all if the
-    ///     entry is not JSON-mapped.
+    ///     Whether this entity type is written as part of another's document rather than on its
+    ///     own.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <b>Two ways to be part of one document, and only one of them is visible in a
+    ///         relational model.</b> A <c>ToJson()</c> type declares a container column and says so
+    ///         through <c>FindContainerName</c>. On a store that has no tables at all, EVERY owned
+    ///         type is part of its owner's document and nothing in the client's model says so,
+    ///         because the client's model is the relational one it always builds.
+    ///     </para>
+    ///     <para>
+    ///         <b>So the deployment says it, through
+    ///         <c>UseNonRelationalServerStore()</c></b>, which already exists and already means
+    ///         exactly this. Answering <see langword="true" /> for a type that is not owned costs
+    ///         nothing: the ownership walk below finds no owner and yields.
+    ///     </para>
+    /// </remarks>
+    private bool PartOfOneDocument(Microsoft.EntityFrameworkCore.Metadata.IEntityType entityType)
+        => !_serverStoreIsRelational || _documentMapping.FindContainerName(entityType) is not null;
+
+    /// <summary>
+    ///     The chain of owners above a document-mapped entry, nearest first, or nothing at all if
+    ///     the entry is not part of another's document.
     /// </summary>
     /// <remarks>
     ///     <c>GetContainerColumnName()</c> is the same question
@@ -388,7 +449,7 @@ public class InfoCarrierDatabase(
     /// </remarks>
     private IEnumerable<IUpdateEntry> JsonColumnOwners(IUpdateEntry entry)
     {
-        if (_documentMapping.FindContainerName(entry.EntityType) is null)
+        if (!PartOfOneDocument(entry.EntityType))
         {
             yield break;
         }

--- a/test/InfoCarrier.Core.DocumentStoreTests/DocumentStoreFixture.cs
+++ b/test/InfoCarrier.Core.DocumentStoreTests/DocumentStoreFixture.cs
@@ -1,0 +1,159 @@
+// Licensed under the MIT license. See license.txt file in the project root for license information.
+
+using InfoCarrier.Core.Common;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Mongo2Go;
+using Xunit;
+
+namespace InfoCarrier.Core.DocumentStoreTests;
+
+/// <summary>
+///     One MongoDB server, owned by one test class, for the life of that class.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>THE PROCESS IS OWNED BY THE STORE, WHICH IS WHAT MAKES ITS LIFETIME OBVIOUS.</b> A
+///         shared server would be cheaper on paper, and it was the first design. It was dropped
+///         because xUnit 2.x has no assembly-level fixture: sharing needs a static that is never
+///         disposed, which orphans a process when a run is killed, and it reintroduces the class of
+///         bug that already cost this repository a nine-test intermittent when a shared SQLite
+///         store's disposal raced a live one. Here the class that started the server stops it, and
+///         there is nothing to get wrong.
+///     </para>
+///     <para>
+///         <b>The cost of that choice was measured rather than assumed.</b> Starting mongod as a
+///         single-node replica set is about 930 ms warm, and it uses about 150 MB, not the 7.6 GB
+///         its WiredTiger cache is configured for. xUnit runs test classes in PARALLEL, so N
+///         classes start N servers at the same time: the wall clock cost is roughly one startup
+///         rather than N, and the memory ceiling is set by core count rather than by how large this
+///         tier grows.
+///     </para>
+///     <para>
+///         <b>A REPLICA SET, NOT A STANDALONE, AND THAT IS NOT OPTIONAL.</b> The MongoDB EF
+///         provider wraps <c>SaveChanges</c> in a transaction so that a multi-document write
+///         applies wholly or not at all, and MongoDB has transactions only on a replica set. A
+///         standalone <c>MongoDbRunner.Start()</c> throws on the first save, which is how this was
+///         found.
+///     </para>
+/// </remarks>
+public sealed class DocumentStoreFixture : IAsyncLifetime
+{
+    private MongoDbRunner _runner = null!;
+    private ServiceProvider _serverProvider = null!;
+
+    /// <summary>
+    ///     Options for a client whose server is this store.
+    /// </summary>
+    public DbContextOptions<ShopClientContext> ClientOptions { get; private set; } = null!;
+
+    /// <summary>
+    ///     Options for a client told that its server is not relational.
+    /// </summary>
+    public DbContextOptions<ShopClientContext> NonRelationalClientOptions { get; private set; } = null!;
+
+    /// <summary>
+    ///     The server this store runs, for the few assertions that are about the store rather than
+    ///     about the wire.
+    /// </summary>
+    public IServiceProvider ServerProvider => _serverProvider;
+
+    public async Task InitializeAsync()
+    {
+        _runner = MongoDbRunner.Start(singleNodeReplSet: true);
+
+        var services = new ServiceCollection();
+        services.AddDbContext<ShopServerContext>(
+            o => o.UseMongoDB(_runner.ConnectionString, "shop"));
+        services.AddScoped<DbContext>(sp => sp.GetRequiredService<ShopServerContext>());
+        _serverProvider = services.BuildServiceProvider();
+
+        using (IServiceScope scope = _serverProvider.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ShopServerContext>();
+            await db.Database.EnsureCreatedAsync();
+            db.Customers.AddRange(Seed());
+            await db.SaveChangesAsync();
+        }
+
+        var serializer = new SystemTextJsonInfoCarrierSerializer();
+        var envelopeServer = new InfoCarrierEnvelopeServer(
+            new InProcessInfoCarrierServer(_serverProvider), serializer);
+        var transport = new WireTransport(envelopeServer, serializer);
+
+        ClientOptions = new DbContextOptionsBuilder<ShopClientContext>()
+            .UseInfoCarrier(new TransportInfoCarrierClient(transport, serializer))
+            .Options;
+
+        NonRelationalClientOptions = new DbContextOptionsBuilder<ShopClientContext>()
+            .UseInfoCarrier(
+                new TransportInfoCarrierClient(transport, serializer),
+                o => o.UseNonRelationalServerStore())
+            .Options;
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _serverProvider.DisposeAsync();
+        _runner.Dispose();
+    }
+
+    /// <summary>A client for a test to use.</summary>
+    public ShopClientContext CreateClient() => new(ClientOptions);
+
+    /// <summary>A client told the server is a document store.</summary>
+    public ShopClientContext CreateNonRelationalClient() => new(NonRelationalClientOptions);
+
+    /// <summary>
+    ///     Three customers, shaped so that nesting is what distinguishes them.
+    /// </summary>
+    public static Customer[] Seed()
+        =>
+        [
+            new Customer
+            {
+                Id = "alice",
+                Name = "Alice",
+                Country = "DE",
+                Address = new Address { City = "Berlin", Postcode = "10115" },
+                Lines = [new OrderLine { Sku = "book", Quantity = 2 }],
+            },
+            new Customer
+            {
+                Id = "bob",
+                Name = "Bob",
+                Country = "PT",
+                Address = new Address { City = "Lisbon", Postcode = "1100" },
+                Lines =
+                [
+                    new OrderLine { Sku = "book", Quantity = 1 },
+                    new OrderLine { Sku = "lamp", Quantity = 3 },
+                ],
+            },
+            new Customer
+            {
+                Id = "carol",
+                Name = "Carol",
+                Country = "DE",
+                Address = new Address { City = "Hamburg", Postcode = "20095" },
+                Lines = [],
+            },
+        ];
+
+    /// <summary>
+    ///     Round-trips every envelope through real serialization, so a wire-format failure surfaces
+    ///     here exactly as it would over a network.
+    /// </summary>
+    private sealed class WireTransport(InfoCarrierEnvelopeServer server, IInfoCarrierSerializer serializer)
+        : IInfoCarrierTransport
+    {
+        public async Task<InfoCarrierEnvelope> SendAsync(
+            InfoCarrierEnvelope request, CancellationToken cancellationToken = default)
+        {
+            InfoCarrierEnvelope onTheWire =
+                serializer.Deserialize<InfoCarrierEnvelope>(serializer.Serialize(request))!;
+            InfoCarrierEnvelope response = await server.DispatchAsync(onTheWire, cancellationToken);
+            return serializer.Deserialize<InfoCarrierEnvelope>(serializer.Serialize(response))!;
+        }
+    }
+}

--- a/test/InfoCarrier.Core.DocumentStoreTests/DocumentWriteTest.cs
+++ b/test/InfoCarrier.Core.DocumentStoreTests/DocumentWriteTest.cs
@@ -1,0 +1,138 @@
+// Licensed under the MIT license. See license.txt file in the project root for license information.
+
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace InfoCarrier.Core.DocumentStoreTests;
+
+/// <summary>
+///     Writes that cross the wire and land in a document store.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>A separate class so it gets a separate fixture, and therefore a separate server.</b>
+///         That is deliberate: these tests mutate the seed, and the query class must not see the
+///         mutation. It is also what makes this tier's parallelism honest, because xUnit runs the
+///         classes at the same time against independent servers.
+///     </para>
+///     <para>
+///         <b>EVERY CLIENT HERE IS TOLD THE STORE IS NOT RELATIONAL, and that is required
+///         configuration rather than a convenience (#100).</b> A change to any part of a document
+///         can only be written by writing the whole document, so the client has to send the whole
+///         document, and it only knows to do that when the deployment has said what the store is.
+///         `UseNonRelationalServerStore()` already carries exactly that statement and already
+///         governs which queries the client will compose; it now governs how much of a document
+///         travels with a change.
+///     </para>
+///     <para>
+///         <b>A client that does NOT say it, against a document store, is misconfigured</b> in the
+///         same way it already was for queries. `NonRelationalStoreTest` keeps one deliberately
+///         misconfigured client so the difference between the two is visible.
+///     </para>
+/// </remarks>
+public class DocumentWriteTest(DocumentStoreFixture fixture) : IClassFixture<DocumentStoreFixture>
+{
+    [Fact]
+    public async Task An_insert_carrying_nested_shapes_round_trips()
+    {
+        await using (ShopClientContext write = fixture.CreateNonRelationalClient())
+        {
+            write.Customers.Add(new Customer
+            {
+                Id = "dave",
+                Name = "Dave",
+                Country = "NL",
+                Address = new Address { City = "Utrecht", Postcode = "3511" },
+                Lines = [new OrderLine { Sku = "desk", Quantity = 1 }],
+            });
+            await write.SaveChangesAsync();
+        }
+
+        await using ShopClientContext read = fixture.CreateNonRelationalClient();
+        Customer dave = await read.Customers.SingleAsync(c => c.Id == "dave");
+
+        Assert.Equal("Utrecht", dave.Address.City);
+        Assert.Equal("desk", Assert.Single(dave.Lines).Sku);
+    }
+
+    [Fact]
+    public async Task Updating_a_nested_document_persists()
+    {
+        await using (ShopClientContext write = fixture.CreateNonRelationalClient())
+        {
+            Customer alice = await write.Customers.SingleAsync(c => c.Id == "alice");
+            alice.Address.City = "Munich";
+            await write.SaveChangesAsync();
+        }
+
+        await using ShopClientContext read = fixture.CreateNonRelationalClient();
+        Assert.Equal("Munich", (await read.Customers.SingleAsync(c => c.Id == "alice")).Address.City);
+    }
+
+    [Fact]
+    public async Task Adding_to_a_nested_array_persists()
+    {
+        await using (ShopClientContext write = fixture.CreateNonRelationalClient())
+        {
+            Customer carol = await write.Customers.SingleAsync(c => c.Id == "carol");
+            carol.Lines.Add(new OrderLine { Sku = "chair", Quantity = 4 });
+            await write.SaveChangesAsync();
+        }
+
+        await using ShopClientContext read = fixture.CreateNonRelationalClient();
+        Customer reloaded = await read.Customers.SingleAsync(c => c.Id == "carol");
+
+        Assert.Equal("chair", Assert.Single(reloaded.Lines).Sku);
+    }
+
+    /// <summary>
+    ///     Updating only a scalar must not disturb the nested documents beside it (#100).
+    /// </summary>
+    /// <remarks>
+    ///     <b>This one is data loss rather than a refusal when it fails</b>, which is why it
+    ///     asserts the read as well as the write: the save reports success and the stored document
+    ///     comes back missing <c>Address</c>.
+    /// </remarks>
+    [Fact]
+    public async Task A_scalar_update_keeps_the_nested_document()
+    {
+        await using (ShopClientContext write = fixture.CreateNonRelationalClient())
+        {
+            Customer bob = await write.Customers.SingleAsync(c => c.Id == "bob");
+            bob.Name = "Robert";
+            await write.SaveChangesAsync();
+        }
+
+        await using ShopClientContext read = fixture.CreateNonRelationalClient();
+        Customer bob2 = await read.Customers.SingleAsync(c => c.Id == "bob");
+
+        Assert.Equal("Robert", bob2.Name);
+        Assert.Equal("Lisbon", bob2.Address.City);
+    }
+
+    [Fact]
+    public async Task A_delete_removes_the_document()
+    {
+        await using (ShopClientContext seed = fixture.CreateNonRelationalClient())
+        {
+            seed.Customers.Add(new Customer
+            {
+                Id = "erin",
+                Name = "Erin",
+                Country = "IE",
+                Address = new Address { City = "Cork", Postcode = "T12" },
+            });
+            await seed.SaveChangesAsync();
+        }
+
+        await using (ShopClientContext write = fixture.CreateNonRelationalClient())
+        {
+            Customer erin = await write.Customers.SingleAsync(c => c.Id == "erin");
+            write.Customers.Remove(erin);
+            await write.SaveChangesAsync();
+        }
+
+        await using ShopClientContext read = fixture.CreateNonRelationalClient();
+        Assert.False(await read.Customers.AnyAsync(c => c.Id == "erin"));
+    }
+}

--- a/test/InfoCarrier.Core.DocumentStoreTests/InfoCarrier.Core.DocumentStoreTests.csproj
+++ b/test/InfoCarrier.Core.DocumentStoreTests/InfoCarrier.Core.DocumentStoreTests.csproj
@@ -1,0 +1,61 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    ADR-009 TIER D: the spec suite's fourth backing store, and the only one that is not a database
+    of tables. It exists to prove a NEGATIVE, that this provider is not relational-only, which the
+    other three tiers can only assert by implication.
+
+    A PROJECT OF ITS OWN, AND THE REASON IS NOT THE ONE THAT SPLIT THE SUITE BEFORE. R136 merged
+    the spec projects back together because the split existed to keep a package off Tier A's
+    compile line and that package was gone. This split has a live reason instead:
+    `MongoDB.EntityFrameworkCore` requires Entity Framework Core >= 10.0.11, and `src/` compiles
+    against a 10.0.1 floor on purpose. Putting them in one project makes central package management
+    refuse the graph (NU1109), and forcing it would drag the whole 29,000-test suite onto a
+    different EF Core patch than the product is built against.
+
+    Keeping it apart also means the EF version the tier runs on is a property of this file rather
+    than of the whole repository, which is exactly what a tier pinning a non-relational store wants.
+
+    NO SPECIFICATION BASES LIVE HERE, so none of EF's spec-test packages are referenced. That is
+    the design and not an omission: Tiers B and C adopt bases to GAIN coverage, and this one owns a
+    small, deliberate set of tests whose green means something no relational store can mean. If a
+    compliance test ever appears here demanding every base be adopted against a document store, it
+    has misread the tier.
+  -->
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!--
+      ABOVE THE FLOOR `src/` COMPILES AGAINST, DELIBERATELY. The Mongo provider requires >= 10.0.11
+      and this repository ships against >= 10.0.1, so this project runs the product on a NEWER EF
+      Core than it was built with. That is the configuration a consumer is really in, and the one
+      that would have caught the defect 10.1.1 fixed.
+    -->
+    <PackageReference Include="Microsoft.EntityFrameworkCore" VersionOverride="10.0.11" />
+
+    <!--
+      THE EF BUMP CASCADES, and this is the whole cost of running one project above the repository
+      floor. EF Core 10.0.11 reaches Microsoft.Extensions.Logging 10.0.11, which floors
+      Microsoft.Extensions.DependencyInjection at 10.0.11, above the 10.0.9 pinned centrally. The
+      override is local to this project, so `src/` and the main suite keep the versions they ship
+      against.
+    -->
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" VersionOverride="10.0.11" />
+    <PackageReference Include="Mongo2Go" />
+    <PackageReference Include="MongoDB.EntityFrameworkCore" />
+
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\InfoCarrier.Core\InfoCarrier.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/InfoCarrier.Core.DocumentStoreTests/NestedDocumentTest.cs
+++ b/test/InfoCarrier.Core.DocumentStoreTests/NestedDocumentTest.cs
@@ -1,0 +1,137 @@
+// Licensed under the MIT license. See license.txt file in the project root for license information.
+
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace InfoCarrier.Core.DocumentStoreTests;
+
+/// <summary>
+///     Queries over a shape that has no tables: a document inside a document, and an array inside
+///     a document.
+/// </summary>
+/// <remarks>
+///     <b>This is the half of Tier D that no other tier can express.</b> Against SQLite or Firebird
+///     the same model becomes tables and joins, so a green test there proves the client can compose
+///     over a relational store. Here there is no join to be got right or wrong, and a green test
+///     proves the client did not need one.
+/// </remarks>
+public class NestedDocumentTest(DocumentStoreFixture fixture) : IClassFixture<DocumentStoreFixture>
+{
+    [Fact]
+    public async Task Every_seeded_customer_round_trips()
+    {
+        await using ShopClientContext db = fixture.CreateClient();
+
+        List<Customer> all = await db.Customers.OrderBy(c => c.Id).ToListAsync();
+
+        Assert.Equal(3, all.Count);
+        Assert.Equal(["alice", "bob", "carol"], all.Select(c => c.Id));
+    }
+
+    [Fact]
+    public async Task A_nested_document_comes_back_populated()
+    {
+        await using ShopClientContext db = fixture.CreateClient();
+
+        Customer alice = await db.Customers.SingleAsync(c => c.Id == "alice");
+
+        Assert.Equal("Berlin", alice.Address.City);
+        Assert.Equal("10115", alice.Address.Postcode);
+    }
+
+    [Fact]
+    public async Task A_filter_reaches_into_a_nested_document()
+    {
+        await using ShopClientContext db = fixture.CreateClient();
+
+        List<Customer> berlin = await db.Customers
+            .Where(c => c.Address.City == "Berlin")
+            .ToListAsync();
+
+        Assert.Equal("alice", Assert.Single(berlin).Id);
+    }
+
+    [Fact]
+    public async Task A_projection_reaches_into_a_nested_document()
+    {
+        await using ShopClientContext db = fixture.CreateClient();
+
+        var rows = await db.Customers
+            .OrderBy(c => c.Id)
+            .Select(c => new { c.Name, c.Address.City })
+            .ToListAsync();
+
+        Assert.Equal(3, rows.Count);
+        Assert.Equal("Berlin", rows[0].City);
+        Assert.Equal("Lisbon", rows[1].City);
+    }
+
+    [Fact]
+    public async Task Ordering_by_a_nested_property_works()
+    {
+        await using ShopClientContext db = fixture.CreateClient();
+
+        List<string> cities = await db.Customers
+            .OrderBy(c => c.Address.City)
+            .Select(c => c.Address.City)
+            .ToListAsync();
+
+        Assert.Equal(["Berlin", "Hamburg", "Lisbon"], cities);
+    }
+
+    [Fact]
+    public async Task A_nested_array_comes_back_with_its_elements()
+    {
+        await using ShopClientContext db = fixture.CreateClient();
+
+        Customer bob = await db.Customers.SingleAsync(c => c.Id == "bob");
+
+        Assert.Equal(2, bob.Lines.Count);
+        Assert.Contains(bob.Lines, l => l.Sku == "lamp" && l.Quantity == 3);
+    }
+
+    [Fact]
+    public async Task An_empty_nested_array_comes_back_empty_rather_than_null()
+    {
+        await using ShopClientContext db = fixture.CreateClient();
+
+        Customer carol = await db.Customers.SingleAsync(c => c.Id == "carol");
+
+        Assert.NotNull(carol.Lines);
+        Assert.Empty(carol.Lines);
+    }
+
+    [Fact]
+    public async Task A_scalar_aggregate_is_answered_by_the_store()
+    {
+        await using ShopClientContext db = fixture.CreateClient();
+
+        Assert.Equal(2, await db.Customers.CountAsync(c => c.Country == "DE"));
+    }
+
+    [Fact]
+    public async Task Paging_over_documents_works()
+    {
+        await using ShopClientContext db = fixture.CreateClient();
+
+        List<string> page = await db.Customers
+            .OrderBy(c => c.Id)
+            .Skip(1)
+            .Take(1)
+            .Select(c => c.Id)
+            .ToListAsync();
+
+        Assert.Equal("bob", Assert.Single(page));
+    }
+
+    [Fact]
+    public async Task Find_by_a_string_key_works()
+    {
+        await using ShopClientContext db = fixture.CreateClient();
+
+        Customer? found = await db.Customers.FindAsync("carol");
+
+        Assert.NotNull(found);
+        Assert.Equal("Hamburg", found.Address.City);
+    }
+}

--- a/test/InfoCarrier.Core.DocumentStoreTests/NonRelationalStoreTest.cs
+++ b/test/InfoCarrier.Core.DocumentStoreTests/NonRelationalStoreTest.cs
@@ -1,0 +1,106 @@
+// Licensed under the MIT license. See license.txt file in the project root for license information.
+
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace InfoCarrier.Core.DocumentStoreTests;
+
+/// <summary>
+///     The claim this whole tier exists to test: that this provider is not relational-only.
+/// </summary>
+/// <remarks>
+///     <b>READ-ONLY, AND THAT IS LOAD-BEARING.</b> Tests in one class share one fixture and run in
+///     an arbitrary order, so a test asserting an absolute count cannot sit beside one that writes.
+///     Three tests here failed exactly that way on the tier's first run. Every write lives in
+///     <see cref="DocumentWriteTest" />, which owns its own server and asserts only on rows it
+///     created.
+/// </remarks>
+/// <remarks>
+///     <para>
+///         <b>`InMemorySmokeTest` already makes this claim and calls its own evidence weak, by
+///         name.</b> Its comment reads: "WEAK EVIDENCE ON PURPOSE, and issue #51 says why: InMemory
+///         has no nested-document shape and no translation refusals of its own, so it disagrees
+///         with a relational store about almost nothing. A document-store tier is what would answer
+///         the question properly. This is the cheap half." This class is the other half.
+///     </para>
+///     <para>
+///         <b>`UseNonRelationalServerStore()` is the API under test.</b> It lifts three refusals on
+///         the argument that a non-relational store answers those queries. Until this tier existed
+///         that argument had never been checked against a store which actually has the property:
+///         the only non-relational store in the suite answers everything and refuses nothing.
+///     </para>
+/// </remarks>
+public class NonRelationalStoreTest(DocumentStoreFixture fixture) : IClassFixture<DocumentStoreFixture>
+{
+    [Fact]
+    public async Task The_client_works_without_being_told_the_store_is_not_relational()
+    {
+        // The default is the relational one, and a document store still answers ordinary queries.
+        await using ShopClientContext db = fixture.CreateClient();
+
+        Assert.Equal(3, await db.Customers.CountAsync());
+    }
+
+    [Fact]
+    public async Task The_client_works_when_told_the_store_is_not_relational()
+    {
+        await using ShopClientContext db = fixture.CreateNonRelationalClient();
+
+        List<Customer> all = await db.Customers.OrderBy(c => c.Id).ToListAsync();
+
+        Assert.Equal(3, all.Count);
+        Assert.Equal("Berlin", all[0].Address.City);
+    }
+
+    /// <summary>
+    ///     The refusal the switch exists to lift, against a store that genuinely answers it.
+    /// </summary>
+    /// <remarks>
+    ///     <b>By default the client refuses a <c>Distinct</c> over a projection carrying a
+    ///     collection</b>, because every relational provider does: the identifying columns do not
+    ///     survive it. A document store has no such problem. This asserts the two directions
+    ///     differ, which is the switch's entire premise and the thing InMemory could not show.
+    /// </remarks>
+    [Fact]
+    public async Task Distinct_over_a_collection_projection_is_refused_by_default_and_allowed_when_told()
+    {
+        await using (ShopClientContext relational = fixture.CreateClient())
+        {
+            await Assert.ThrowsAnyAsync<Exception>(
+                () => relational.Customers
+                    .Select(c => new { c.Name, c.Lines })
+                    .Distinct()
+                    .ToListAsync());
+        }
+
+        await using ShopClientContext document = fixture.CreateNonRelationalClient();
+        var rows = await document.Customers
+            .Select(c => new { c.Name, c.Lines })
+            .Distinct()
+            .ToListAsync();
+
+        Assert.Equal(3, rows.Count);
+    }
+
+    /// <summary>
+    ///     The relational model is never built, on a store where it would mean nothing.
+    /// </summary>
+    /// <remarks>
+    ///     <b>The other half of the claim, and the one that would catch a regression.</b> Since V5
+    ///     the client CAN build EF's relational model and puts a lazy factory on every model to do
+    ///     it. If some future code path started forcing that factory, every query against every
+    ///     store would pay for it, including one with no tables at all. `InMemorySmokeTest` pins
+    ///     this against a store that merely has no tables; this pins it against one whose documents
+    ///     are not tables even in principle.
+    /// </remarks>
+    [Fact]
+    public async Task Ordinary_use_never_builds_the_relational_model()
+    {
+        await using ShopClientContext db = fixture.CreateNonRelationalClient();
+
+        Assert.Single(await db.Customers.Where(c => c.Address.City == "Berlin").ToListAsync());
+
+        Assert.NotNull(db.Model.FindRuntimeAnnotation("Relational:RelationalModelFactory"));
+        Assert.Null(db.Model.FindRuntimeAnnotation("Relational:RelationalModel"));
+    }
+}

--- a/test/InfoCarrier.Core.DocumentStoreTests/ServerSideControlTest.cs
+++ b/test/InfoCarrier.Core.DocumentStoreTests/ServerSideControlTest.cs
@@ -1,0 +1,98 @@
+// Licensed under the MIT license. See license.txt file in the project root for license information.
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace InfoCarrier.Core.DocumentStoreTests;
+
+/// <summary>
+///     The same writes, run directly against the server with InfoCarrier out of the picture.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>THIS CLASS IS A CONTROL AND NOTHING ELSE.</b> It tests EF Core and the MongoDB
+///         provider, neither of which is this repository's code, and it earns its place only by
+///         answering a question no other test can: when an update through the wire fails, is the
+///         wire at fault or is the store?
+///     </para>
+///     <para>
+///         <b>It exists because the tier's first run failed three update tests</b> with
+///         "the entity of type 'Address' is mapped as a part of the document mapped to 'Customer',
+///         but there is no tracked entity of this type with the corresponding key value", and one
+///         with "Field 'Address' required but not present in BsonDocument". Those messages are
+///         about owned entities and document shape, which is precisely the seam where this
+///         provider and a document store could each plausibly be wrong. Guessing which would have
+///         been the same mistake as reporting a Mongo failure that turned out to be an EF version
+///         defect, which happened once already.
+///     </para>
+///     <para>
+///         <b>Read it as a fork.</b> If these pass and the wire tests fail, the fault is on this
+///         side of the wire. If these fail too, the fault is below us and the wire tests are
+///         describing somebody else's behaviour.
+///     </para>
+/// </remarks>
+public class ServerSideControlTest(DocumentStoreFixture fixture) : IClassFixture<DocumentStoreFixture>
+{
+    private ShopServerContext Server(IServiceScope scope)
+        => scope.ServiceProvider.GetRequiredService<ShopServerContext>();
+
+    [Fact]
+    public async Task Server_side_scalar_update_keeps_the_nested_document()
+    {
+        using (IServiceScope scope = fixture.ServerProvider.CreateScope())
+        {
+            ShopServerContext db = Server(scope);
+            Customer bob = await db.Customers.SingleAsync(c => c.Id == "bob");
+            bob.Name = "Robert";
+            await db.SaveChangesAsync();
+        }
+
+        using (IServiceScope scope = fixture.ServerProvider.CreateScope())
+        {
+            ShopServerContext db = Server(scope);
+            Customer bob = await db.Customers.SingleAsync(c => c.Id == "bob");
+
+            Assert.Equal("Robert", bob.Name);
+            Assert.Equal("Lisbon", bob.Address.City);
+        }
+    }
+
+    [Fact]
+    public async Task Server_side_nested_document_update_persists()
+    {
+        using (IServiceScope scope = fixture.ServerProvider.CreateScope())
+        {
+            ShopServerContext db = Server(scope);
+            Customer alice = await db.Customers.SingleAsync(c => c.Id == "alice");
+            alice.Address.City = "Munich";
+            await db.SaveChangesAsync();
+        }
+
+        using (IServiceScope scope = fixture.ServerProvider.CreateScope())
+        {
+            ShopServerContext db = Server(scope);
+            Assert.Equal("Munich", (await db.Customers.SingleAsync(c => c.Id == "alice")).Address.City);
+        }
+    }
+
+    [Fact]
+    public async Task Server_side_nested_array_append_persists()
+    {
+        using (IServiceScope scope = fixture.ServerProvider.CreateScope())
+        {
+            ShopServerContext db = Server(scope);
+            Customer carol = await db.Customers.SingleAsync(c => c.Id == "carol");
+            carol.Lines.Add(new OrderLine { Sku = "chair", Quantity = 4 });
+            await db.SaveChangesAsync();
+        }
+
+        using (IServiceScope scope = fixture.ServerProvider.CreateScope())
+        {
+            ShopServerContext db = Server(scope);
+            Customer carol = await db.Customers.SingleAsync(c => c.Id == "carol");
+
+            Assert.Equal("chair", Assert.Single(carol.Lines).Sku);
+        }
+    }
+}

--- a/test/InfoCarrier.Core.DocumentStoreTests/ShopModel.cs
+++ b/test/InfoCarrier.Core.DocumentStoreTests/ShopModel.cs
@@ -1,0 +1,89 @@
+// Licensed under the MIT license. See license.txt file in the project root for license information.
+
+using Microsoft.EntityFrameworkCore;
+using MongoDB.EntityFrameworkCore.Extensions;
+
+namespace InfoCarrier.Core.DocumentStoreTests;
+
+/// <summary>
+///     The one model this tier uses, and it is shaped like a document on purpose.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>A nested object AND a nested array</b>, because that is the shape a relational store
+///         cannot hold without joining. <c>Address</c> is one document inside another;
+///         <c>Lines</c> is an array inside one. Against SQLite these become tables and a join;
+///         against MongoDB they are simply there, and no join exists to get them wrong.
+///     </para>
+///     <para>
+///         <b>THE KEY IS A STRING, AND THAT IS A FINDING RATHER THAN A PREFERENCE.</b> MongoDB's
+///         natural key type is <c>ObjectId</c>, and the CLIENT cannot map it: the client has no
+///         MongoDB provider, so a Mongo-native type is not in its model at all and the shared model
+///         fails to build. A key type both halves understand is therefore a REQUIREMENT of this
+///         architecture against a document store, not a convenience, and it was found by trying.
+///     </para>
+/// </remarks>
+public class Customer
+{
+    public string Id { get; set; } = null!;
+
+    public string Name { get; set; } = null!;
+
+    public string Country { get; set; } = null!;
+
+    /// <summary>A document inside a document.</summary>
+    public Address Address { get; set; } = null!;
+
+    /// <summary>An array inside a document.</summary>
+    public List<OrderLine> Lines { get; set; } = [];
+}
+
+/// <summary>Nested, and never a table of its own on this store.</summary>
+public class Address
+{
+    public string City { get; set; } = null!;
+
+    public string Postcode { get; set; } = null!;
+}
+
+/// <summary>One element of the nested array.</summary>
+public class OrderLine
+{
+    public string Sku { get; set; } = null!;
+
+    public int Quantity { get; set; }
+}
+
+/// <summary>
+///     The SERVER's model, which knows it is MongoDB.
+/// </summary>
+/// <remarks>
+///     <c>ToCollection</c> is the Mongo provider's own extension. The client below cannot say it,
+///     which is the asymmetry this tier exists to exercise: the two halves describe the same
+///     entities and only one of them knows what the store is.
+/// </remarks>
+public class ShopServerContext(DbContextOptions<ShopServerContext> options) : DbContext(options)
+{
+    public DbSet<Customer> Customers => Set<Customer>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Customer>().ToCollection("customers");
+        modelBuilder.Entity<Customer>().OwnsOne(c => c.Address);
+        modelBuilder.Entity<Customer>().OwnsMany(c => c.Lines);
+    }
+}
+
+/// <summary>
+///     The CLIENT's model, which has no database and no idea what the store is.
+/// </summary>
+public class ShopClientContext(DbContextOptions<ShopClientContext> options) : DbContext(options)
+{
+    public DbSet<Customer> Customers => Set<Customer>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Customer>().OwnsOne(c => c.Address);
+        modelBuilder.Entity<Customer>().OwnsMany(c => c.Lines);
+    }
+}


### PR DESCRIPTION
Closes the measurement half of #51 and fixes #100.

## The tier

Every store this repository tested against was relational or InMemory, so the claim that this provider is not relational-only rested on InMemory, which has no nested-document shape and refuses nothing. `InMemorySmokeTest` says so itself and calls its evidence *"the cheap half"*. This is the other half: 22 tests over a shape with no tables, a document inside a document and an array inside one.

**It adopts no specification bases and has no compliance test.** Tiers B and C were added to *gain* coverage; this one proves a **negative**. A compliance test scanning the core assembly would demand every base be adopted against a document store, which is neither possible nor the point.

Some deliberate choices, each measured rather than assumed:

- **Mongo2Go, not EphemeralMongo** — the trade Firebird won. ADR-009 rejected PostgreSQL for fetching binaries at first run, and EphemeralMongo does exactly that. Mongo2Go carries `mongod` inside its own package.
- **One server per store, owned by the test class.** Sharing is cheaper on paper (~108 ms per further database against ~930 ms per further server) and was rejected: xUnit 2.x has no assembly-level fixture, so sharing needs a static that is never disposed, and it reintroduces the class of bug that cost this repo a nine-test intermittent when a shared SQLite store's disposal raced a live one.
- **Cost is bounded by concurrency, not tier size.** Classes run in parallel, a `mongod` holding a test dataset uses ~150 MB rather than the 7.6 GB its cache is configured for, and 22 tests across four servers take about seven seconds including every start. The tier can grow.
- **A project of its own**, for a reason R136 did not have: `MongoDB.EntityFrameworkCore` requires EF Core >= 10.0.11 while `src/` compiles against a 10.0.1 floor. That also makes it the one place the product runs on a **newer** EF Core than it was built with, which is the configuration a consumer is really in.

## The defect it found, and the fix

Updating an entity that owns nested documents lost them over the wire. A scalar update lost them **silently**, writing a document with the nested parts gone and failing only on the next read.

`ServerSideControlTest` performs the same updates directly against MongoDB with this provider out of the way, and passes throughout — so the store was never at fault.

**The same defect had already been solved once, for JSON columns** (C86, C87, C95). An owner that is `Unchanged` never reaches `IDatabase.SaveChanges`, so `InfoCarrierDatabase.Expand` sends it anyway. That machinery was bounded by `GetContainerColumnName()`, a **relational** question that a document store answers nowhere, which is exactly why it was blind here.

Two changes:

1. **The bound widens** to any owned type when the store is not relational.
2. **The direction the JSON case never needed**: a *root* being written pulls its own document along, because writing a customer writes the whole customer document. This is the silent data-loss case.

**Gated on `UseNonRelationalServerStore()`, so a relational deployment sends exactly what it sent before.** That switch already states the store is not relational and already decides which queries the client composes; it now decides how much of a document travels with a change. A client pointed at a document store must set it, which was already true for queries.

## Verification

**The fix is load-bearing, checked rather than assumed:** with the product change removed and the tests untouched, the same three fail again.

| Gate | Result |
|---|---|
| Tier D | 22/22, asserting correct behaviour |
| Spec suite | `FAILING 19, TOTAL 29558` — fixed none, broken none, reasons unchanged, byte-identical to baseline |
| TransportTests | 26/26 |
| `CI=true` Release build | 5 warnings, 0 errors |
| trim-ratchet | 90 ≤ 90 |
| `dotnet pack` | clean |
| Doc links | clean |

The spec-suite row is the one that matters: **Tier A declares `ServerStoreIsRelational => false`**, so roughly 8,777 InMemory tests take the new save path, and none of them moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
